### PR TITLE
feat: Add Undo/Redo feature in padavali and padajala puzzle editors

### DIFF
--- a/src/components/pages/cross_word/ViewEditCrossword.tsx
+++ b/src/components/pages/cross_word/ViewEditCrossword.tsx
@@ -237,7 +237,6 @@ const CrosswordPuzzleImageSection = ({ puzzleId }: { puzzleId: number }) => {
   const [title] = useAtom(title_atom);
   const [description] = useAtom(description_atom);
   const [wordList] = useAtom(word_list_atom);
-  const { acceptKeysAsSaved } = useEditorHistoryActions();
 
   return (
     <PuzzleCardImageSection
@@ -250,10 +249,7 @@ const CrosswordPuzzleImageSection = ({ puzzleId }: { puzzleId: number }) => {
       imageInfo={image_info}
       onImageIdChange={setImageId}
       onImageInfoChange={setImageInfo}
-      onImageBaselineChange={(id) => {
-        setImageBaseline(id);
-        acceptKeysAsSaved('image_id', 'image_info');
-      }}
+      onImageBaselineChange={setImageBaseline}
     />
   );
 };
@@ -1138,27 +1134,38 @@ const SaveControls = ({ puzzle }: { puzzle: ViewEditCrosswordProps['puzzle'] }) 
   const [attachments, setAttachments] = useAtom(attachments_atom);
   const [image_id, setImageId] = useAtom(image_id_atom);
   const [, setImageBaseline] = useAtom(image_baseline_atom);
-  const { markSaved } = useEditorHistoryActions();
+  const { beginSave, markSaved } = useEditorHistoryActions();
+  const saveSnapRef = useRef<{
+    attachments: EditableAttachment[];
+    image_id: number | null;
+  } | null>(null);
 
   const update_mut = client_q.crossword.update_puzzle.useMutation({
     onSuccess: (data) => {
       toast.success('Puzzle updated successfully');
 
+      const submitted = saveSnapRef.current;
+      const baseAttachments = submitted?.attachments ?? attachments;
+      const savedImageId = submitted?.image_id ?? image_id;
+
       const updatedAttachments =
         data.newly_added_index_ids.length > 0
-          ? attachments.map((val, i) => {
+          ? baseAttachments.map((val, i) => {
               const elm = data.newly_added_index_ids.find(({ index }) => index === i);
               return elm ? { ...val, id: elm.id } : val;
             })
-          : attachments;
+          : baseAttachments;
 
       if (data.newly_added_index_ids.length > 0) {
         setAttachments(updatedAttachments);
       }
 
-      setImageBaseline(image_id);
-      setImageId(image_id);
-      markSaved();
+      setImageBaseline(savedImageId);
+      setImageId(savedImageId);
+      markSaved(
+        data.newly_added_index_ids.length > 0 ? { attachments: updatedAttachments } : undefined
+      );
+      saveSnapRef.current = null;
 
       void queryClient.invalidateQueries({ queryKey: ['crossword_list'] });
       void invalidatePage('/padajala');
@@ -1168,6 +1175,7 @@ const SaveControls = ({ puzzle }: { puzzle: ViewEditCrosswordProps['puzzle'] }) 
       void invalidatePage(`/padajala/${puzzle.slug}`);
     },
     onError(err) {
+      saveSnapRef.current = null;
       toast.error(err.message || 'Failed to update puzzle');
     }
   });
@@ -1230,6 +1238,8 @@ const SaveControls = ({ puzzle }: { puzzle: ViewEditCrosswordProps['puzzle'] }) 
 
     const parse = crossword_update_input_schema.safeParse(data);
     if (parse.success) {
+      beginSave();
+      saveSnapRef.current = { attachments, image_id };
       update_mut.mutate(parse.data);
     } else {
       console.error(parse.error);

--- a/src/components/pages/cross_word/ViewEditCrossword.tsx
+++ b/src/components/pages/cross_word/ViewEditCrossword.tsx
@@ -7,7 +7,6 @@ import { useRouter } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ArrowRight, Info, Pencil } from 'lucide-react';
-import { FiSave } from 'react-icons/fi';
 import { IoMdAdd, IoMdClose } from 'react-icons/io';
 import { MdDeleteOutline, MdDragIndicator } from 'react-icons/md';
 import { toast } from 'sonner';
@@ -92,6 +91,12 @@ import {
 import { invalidatePage } from '~/tools/invalidate_nextjs_server_route';
 import { CrosswordSlugField } from '~/components/pages/cross_word/EditCrosswordSlugDialog';
 import { PuzzleCardImageSection } from '~/components/pages/puzzle/PuzzleCardImageSection';
+import { EditorActionDock } from '~/components/pages/puzzle/EditorActionDock';
+import {
+  EditorHistoryProvider,
+  useEditorHistoryActions,
+  useHistoryTextField
+} from '~/hooks/useEditorHistory';
 
 type EditableWord = {
   id: string;
@@ -126,6 +131,18 @@ const image_info_atom = atom<{ id: number; s3_key: string; width: number; height
   null
 );
 
+const CROSSWORD_HISTORY_ATOMS = {
+  title: title_atom,
+  description: description_atom,
+  listed: listed_atom,
+  grid_dimensions: grid_dimensions_atom,
+  grid_data: grid_data_atom,
+  word_list: word_list_atom,
+  attachments: attachments_atom,
+  image_id: image_id_atom,
+  image_info: image_info_atom
+};
+
 export type ViewEditCrosswordProps = {
   puzzle: CrossordPuzzle & {
     attachments: z.infer<typeof attachment_schema>[];
@@ -156,6 +173,23 @@ function editableWordsComparable(words: EditableWord[]) {
   }));
 }
 
+function crosswordHistoryComparable(snapshot: {
+  title: string;
+  description: string;
+  listed: boolean;
+  grid_dimensions: [number, number];
+  grid_data: CrossordPuzzleGridCell[][];
+  word_list: EditableWord[];
+  attachments: EditableAttachment[];
+  image_id: number | null;
+  image_info: { id: number; s3_key: string; width: number; height: number } | null;
+}) {
+  return {
+    ...snapshot,
+    word_list: editableWordsComparable(snapshot.word_list)
+  };
+}
+
 export default function ViewEditCrossword({ puzzle: initialPuzzle }: ViewEditCrosswordProps) {
   const [puzzle, setPuzzle] = useState(initialPuzzle);
 
@@ -173,24 +207,26 @@ export default function ViewEditCrossword({ puzzle: initialPuzzle }: ViewEditCro
   ]);
 
   return (
-    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-2 py-4 sm:px-4">
-      <CrosswordSlugField
-        slug={puzzle.slug}
-        puzzleId={puzzle.id}
-        onSlugUpdated={(slug) => setPuzzle((prev) => ({ ...prev, slug }))}
-      />
-      <TitleField />
-      <DescriptionField />
-      <div className="flex flex-wrap items-center gap-6">
-        <ListedSwitch />
-        <DimensionsField />
+    <EditorHistoryProvider atoms={CROSSWORD_HISTORY_ATOMS} comparable={crosswordHistoryComparable}>
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-2 py-4 pb-28 sm:px-4">
+        <CrosswordSlugField
+          slug={puzzle.slug}
+          puzzleId={puzzle.id}
+          onSlugUpdated={(slug) => setPuzzle((prev) => ({ ...prev, slug }))}
+        />
+        <TitleField />
+        <DescriptionField />
+        <div className="flex flex-wrap items-center gap-6">
+          <ListedSwitch />
+          <DimensionsField />
+        </div>
+        <WordListEditor />
+        <PlacementAndGrid />
+        <AttachmentsEditor />
+        <CrosswordPuzzleImageSection puzzleId={puzzle.id} />
+        <SaveControls puzzle={puzzle} />
       </div>
-      <WordListEditor />
-      <PlacementAndGrid />
-      <AttachmentsEditor />
-      <CrosswordPuzzleImageSection puzzleId={puzzle.id} />
-      <SaveControls puzzle={puzzle} />
-    </div>
+    </EditorHistoryProvider>
   );
 }
 
@@ -201,6 +237,7 @@ const CrosswordPuzzleImageSection = ({ puzzleId }: { puzzleId: number }) => {
   const [title] = useAtom(title_atom);
   const [description] = useAtom(description_atom);
   const [wordList] = useAtom(word_list_atom);
+  const { acceptKeysAsSaved } = useEditorHistoryActions();
 
   return (
     <PuzzleCardImageSection
@@ -213,13 +250,17 @@ const CrosswordPuzzleImageSection = ({ puzzleId }: { puzzleId: number }) => {
       imageInfo={image_info}
       onImageIdChange={setImageId}
       onImageInfoChange={setImageInfo}
-      onImageBaselineChange={setImageBaseline}
+      onImageBaselineChange={(id) => {
+        setImageBaseline(id);
+        acceptKeysAsSaved('image_id', 'image_info');
+      }}
     />
   );
 };
 
 const TitleField = () => {
   const [title, setTitle] = useAtom(title_atom);
+  const historyField = useHistoryTextField();
   return (
     <div className="flex flex-col gap-2">
       <Label htmlFor="crossword-title" className="text-lg font-semibold">
@@ -229,6 +270,8 @@ const TitleField = () => {
         id="crossword-title"
         value={title}
         onChange={(e) => setTitle(e.currentTarget.value)}
+        onFocus={historyField.onFocus}
+        onBlur={historyField.onBlur}
         className="max-w-xl text-base"
       />
     </div>
@@ -237,6 +280,7 @@ const TitleField = () => {
 
 const DescriptionField = () => {
   const [description, setDescription] = useAtom(description_atom);
+  const historyField = useHistoryTextField();
   return (
     <div className="flex flex-col gap-2">
       <Label htmlFor="crossword-description" className="text-lg font-semibold">
@@ -246,6 +290,8 @@ const DescriptionField = () => {
         id="crossword-description"
         value={description}
         onChange={(e) => setDescription(e.currentTarget.value)}
+        onFocus={historyField.onFocus}
+        onBlur={historyField.onBlur}
         rows={3}
         className="max-w-2xl"
         placeholder="Enter a description for the puzzle..."
@@ -272,6 +318,7 @@ const SortableAttachmentItem = ({
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: `attachment-${index}`
   });
+  const historyField = useHistoryTextField();
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -347,6 +394,8 @@ const SortableAttachmentItem = ({
             value={attachment.url}
             aria-label={`Attachment ${index + 1} URL`}
             onInput={(e) => onUpdate('url', e.currentTarget.value)}
+            onFocus={historyField.onFocus}
+            onBlur={historyField.onBlur}
           />
         </div>
       </div>
@@ -360,6 +409,8 @@ const SortableAttachmentItem = ({
           value={attachment.title ?? ''}
           aria-label={`Attachment ${index + 1} title`}
           onChange={(e) => onUpdate('title', e.currentTarget.value || null)}
+          onFocus={historyField.onFocus}
+          onBlur={historyField.onBlur}
         />
       </div>
     </div>
@@ -598,6 +649,7 @@ const DimensionsField = () => {
 const WordListEditor = () => {
   const [wordList, setWordList] = useAtom(word_list_atom);
   const [gridData] = useAtom(grid_data_atom);
+  const historyField = useHistoryTextField();
 
   const analysis = useMemo(() => analyzeWordPlacements(gridData, wordList), [gridData, wordList]);
 
@@ -647,12 +699,16 @@ const WordListEditor = () => {
                       word: e.currentTarget.value.toUpperCase().replace(/[^A-Z]/g, '')
                     })
                   }
+                  onFocus={historyField.onFocus}
+                  onBlur={historyField.onBlur}
                   placeholder="WORD"
                   className="w-36 font-mono uppercase sm:w-44"
                 />
                 <Input
                   value={item.description}
                   onChange={(e) => updateWord(idx, { description: e.currentTarget.value })}
+                  onFocus={historyField.onFocus}
+                  onBlur={historyField.onBlur}
                   placeholder="Clue / description"
                   className="min-w-0 flex-1"
                 />
@@ -881,6 +937,7 @@ const GridEditor = ({
   const [gridData, setGridData] = useAtom(grid_data_atom);
   const gridRef = useRef<HTMLDivElement>(null);
   const [rows, cols] = dimensions;
+  const historyField = useHistoryTextField();
 
   const updateCell = (r: number, c: number, next: CrossordPuzzleGridCell) => {
     setGridData((prev) => {
@@ -1034,6 +1091,8 @@ const GridEditor = ({
                   value={cell.text}
                   onChange={(e) => setLetter(r, c, e.currentTarget.value)}
                   onKeyDown={(e) => handleCellKeyDown(r, c, e)}
+                  onFocus={historyField.onFocus}
+                  onBlur={historyField.onBlur}
                   className={getCellClassName(r, c)}
                   maxLength={2}
                   aria-label={
@@ -1078,25 +1137,8 @@ const SaveControls = ({ puzzle }: { puzzle: ViewEditCrosswordProps['puzzle'] }) 
   const [wordList] = useAtom(word_list_atom);
   const [attachments, setAttachments] = useAtom(attachments_atom);
   const [image_id, setImageId] = useAtom(image_id_atom);
-  const [image_baseline, setImageBaseline] = useAtom(image_baseline_atom);
-
-  const initialRef = useRef<{
-    title: string;
-    description: string;
-    listed: boolean;
-    gridDimensions: [number, number];
-    gridData: CrossordPuzzleGridCell[][];
-    wordList: EditableWord[];
-    attachments: EditableAttachment[];
-  }>({
-    title: puzzle.title,
-    description: puzzle.description,
-    listed: puzzle.listed,
-    gridDimensions: puzzle.grid_dimensions,
-    gridData: puzzle.grid_data,
-    wordList: toEditableWords(puzzle.word_list),
-    attachments: puzzle.attachments
-  });
+  const [, setImageBaseline] = useAtom(image_baseline_atom);
+  const { markSaved } = useEditorHistoryActions();
 
   const update_mut = client_q.crossword.update_puzzle.useMutation({
     onSuccess: (data) => {
@@ -1116,16 +1158,8 @@ const SaveControls = ({ puzzle }: { puzzle: ViewEditCrosswordProps['puzzle'] }) 
 
       setImageBaseline(image_id);
       setImageId(image_id);
+      markSaved();
 
-      initialRef.current = {
-        title,
-        description,
-        listed,
-        gridDimensions,
-        gridData,
-        wordList,
-        attachments: updatedAttachments
-      };
       void queryClient.invalidateQueries({ queryKey: ['crossword_list'] });
       void invalidatePage('/padajala');
       void invalidatePage('/padajala/list');
@@ -1151,30 +1185,6 @@ const SaveControls = ({ puzzle }: { puzzle: ViewEditCrosswordProps['puzzle'] }) 
       toast.error('Failed to delete puzzle');
     }
   });
-
-  const isEdited = useMemo(() => {
-    return (
-      title !== initialRef.current.title ||
-      description !== initialRef.current.description ||
-      listed !== initialRef.current.listed ||
-      JSON.stringify(gridDimensions) !== JSON.stringify(initialRef.current.gridDimensions) ||
-      JSON.stringify(gridData) !== JSON.stringify(initialRef.current.gridData) ||
-      JSON.stringify(editableWordsComparable(wordList)) !==
-        JSON.stringify(editableWordsComparable(initialRef.current.wordList)) ||
-      JSON.stringify(attachments) !== JSON.stringify(initialRef.current.attachments) ||
-      image_id !== image_baseline
-    );
-  }, [
-    title,
-    description,
-    listed,
-    gridDimensions,
-    gridData,
-    wordList,
-    attachments,
-    image_id,
-    image_baseline
-  ]);
 
   const handleSave = () => {
     if (!description.trim()) {
@@ -1228,57 +1238,35 @@ const SaveControls = ({ puzzle }: { puzzle: ViewEditCrosswordProps['puzzle'] }) 
   };
 
   return (
-    <div className="mx-2 mt-2 flex items-center justify-between sm:mx-4">
-      <AlertDialog>
-        <AlertDialogTrigger
-          render={
-            <Button
-              disabled={!isEdited || update_mut.isPending}
-              className="flex text-lg"
-              variant="outline"
-            />
-          }
-        >
-          <FiSave className="text-lg" /> {!update_mut.isPending ? 'Save' : 'Saving...'}
-        </AlertDialogTrigger>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Confirm Save</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to save your changes?
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleSave}>Confirm</AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+    <>
+      <EditorActionDock onSave={handleSave} isSaving={update_mut.isPending} />
 
-      <AlertDialog>
-        <AlertDialogTrigger
-          render={<Button className="flex gap-1 px-1 py-0 text-sm" variant="destructive" />}
-        >
-          <MdDeleteOutline className="text-base" />
-          Delete
-        </AlertDialogTrigger>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Confirm Delete</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete this puzzle? This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => delete_mut.mutate({ id: puzzle.id, slug: puzzle.slug })}
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </div>
+      <div className="mx-2 mt-2 flex items-center justify-end sm:mx-4">
+        <AlertDialog>
+          <AlertDialogTrigger
+            render={<Button className="flex gap-1 px-1 py-0 text-sm" variant="destructive" />}
+          >
+            <MdDeleteOutline className="text-base" />
+            Delete
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Confirm Delete</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete this puzzle? This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => delete_mut.mutate({ id: puzzle.id, slug: puzzle.slug })}
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </>
   );
 };

--- a/src/components/pages/padavali/ViewEditPuzzle.tsx
+++ b/src/components/pages/padavali/ViewEditPuzzle.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { z } from 'zod';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -28,7 +28,6 @@ import { client_q } from '~/api/client';
 import { toast } from 'sonner';
 import { IoMdAdd, IoMdClose } from 'react-icons/io';
 import { atom, useAtom } from 'jotai';
-import { FiSave } from 'react-icons/fi';
 import { MdDeleteOutline, MdDragIndicator } from 'react-icons/md';
 import { useRouter } from 'next/navigation';
 import { Info, ArrowRight, ExternalLink } from 'lucide-react';
@@ -42,6 +41,7 @@ import {
 import { Textarea } from '@/components/ui/textarea';
 import { Checkbox } from '@/components/ui/checkbox';
 import { PuzzleCardImageSection } from '~/components/pages/puzzle/PuzzleCardImageSection';
+import { EditorActionDock } from '~/components/pages/puzzle/EditorActionDock';
 import {
   DndContext,
   closestCenter,
@@ -94,6 +94,11 @@ import {
 } from '~/components/ui/select';
 import { useQueryClient } from '@tanstack/react-query';
 import { invalidatePage } from '~/tools/invalidate_nextjs_server_route';
+import {
+  EditorHistoryProvider,
+  useEditorHistoryActions,
+  useHistoryTextField
+} from '~/hooks/useEditorHistory';
 
 const ATTACHMENT_TYPE_ITEMS = [
   { label: 'Select attachment type', value: null },
@@ -141,6 +146,17 @@ const image_info_atom = atom<{ id: number; s3_key: string; width: number; height
   null
 );
 
+const PADAVALI_HISTORY_ATOMS = {
+  title: title_atom,
+  description: description_atom,
+  listed: listed_atom,
+  word_list: word_list_atom,
+  grid_data: grid_data_atom,
+  attachments: attachments_atom,
+  image_id: image_id_atom,
+  image_info: image_info_atom
+};
+
 export type ViewEditProps = {
   word_puzzle: Puzzle;
 };
@@ -162,26 +178,28 @@ const ViewEditPuzzle = ({ word_puzzle: initialWordPuzzle }: ViewEditProps) => {
   ]);
 
   return (
-    <Card className="space-y-1.5">
-      <CardContent>
-        <div className="space-y-4">
-          <LipiLekhikaSwitch />
-          <SlugField
-            slug={word_puzzle.slug}
-            puzzleId={word_puzzle.id}
-            onSlugUpdated={(slug) => setWordPuzzle((prev) => ({ ...prev, slug }))}
-          />
-          <Title />
-          <ListedSwitch slug={word_puzzle.slug} />
-          <Description />
-          <Attachments />
-          <WordList />
-          <TraversalAndGridData grid_dimensions={word_puzzle.grid_dimensions} />
-          <PuzzleImageSection word_puzzle={word_puzzle} />
-          <SaveButton word_puzzle={word_puzzle} />
-        </div>
-      </CardContent>
-    </Card>
+    <EditorHistoryProvider atoms={PADAVALI_HISTORY_ATOMS}>
+      <Card className="space-y-1.5 pb-28">
+        <CardContent>
+          <div className="space-y-4">
+            <LipiLekhikaSwitch />
+            <SlugField
+              slug={word_puzzle.slug}
+              puzzleId={word_puzzle.id}
+              onSlugUpdated={(slug) => setWordPuzzle((prev) => ({ ...prev, slug }))}
+            />
+            <Title />
+            <ListedSwitch slug={word_puzzle.slug} />
+            <Description />
+            <Attachments />
+            <WordList />
+            <TraversalAndGridData grid_dimensions={word_puzzle.grid_dimensions} />
+            <PuzzleImageSection word_puzzle={word_puzzle} />
+            <SaveButton word_puzzle={word_puzzle} />
+          </div>
+        </CardContent>
+      </Card>
+    </EditorHistoryProvider>
   );
 };
 
@@ -189,6 +207,7 @@ const Title = () => {
   const ctx = createTypingContext(BASE_SCRIPT);
   const [title, setTitle] = useAtom(title_atom);
   const [lipi_lekhika_active] = useAtom(lipi_lekhika_active_atom);
+  const historyField = useHistoryTextField();
 
   useEffect(() => {
     ctx.ready;
@@ -211,7 +230,11 @@ const Title = () => {
               lipi_lekhika_active
             )
           }
-          onBlur={() => ctx.clearContext()}
+          onFocus={historyField.onFocus}
+          onBlur={() => {
+            ctx.clearContext();
+            historyField.onBlur();
+          }}
           onKeyDown={(e) => clearTypingContextOnKeyDown(e, ctx)}
         />
       </Label>
@@ -243,6 +266,7 @@ const SortableAttachmentItem = ({
 
   const ctx = createTypingContext(BASE_SCRIPT);
   const [lipi_lekhika_active] = useAtom(lipi_lekhika_active_atom);
+  const historyField = useHistoryTextField();
 
   return (
     <div
@@ -304,6 +328,8 @@ const SortableAttachmentItem = ({
             className="w-64 text-sm"
             value={attachment.url}
             onInput={(e) => onUpdate('url', e.currentTarget.value, null)}
+            onFocus={historyField.onFocus}
+            onBlur={historyField.onBlur}
           />
         </div>
       </div>
@@ -324,7 +350,11 @@ const SortableAttachmentItem = ({
               lipi_lekhika_active
             )
           }
-          onBlur={() => ctx.clearContext()}
+          onFocus={historyField.onFocus}
+          onBlur={() => {
+            ctx.clearContext();
+            historyField.onBlur();
+          }}
           onKeyDown={(e) => clearTypingContextOnKeyDown(e, ctx)}
         />
       </div>
@@ -882,6 +912,7 @@ const TraversalAnalysis = ({
 const WordList = () => {
   const [wordList, setWordList] = useAtom(word_list_atom);
   const [lipi_lekhika_active] = useAtom(lipi_lekhika_active_atom);
+  const historyField = useHistoryTextField();
 
   const addWord = () => setWordList((prev) => [...prev, '']);
   const removeWord = (index: number) => setWordList((prev) => prev.filter((_, i) => i !== index));
@@ -921,7 +952,11 @@ const WordList = () => {
                       lipi_lekhika_active
                     )
                   }
-                  onBlur={() => ctx.clearContext()}
+                  onFocus={historyField.onFocus}
+                  onBlur={() => {
+                    ctx.clearContext();
+                    historyField.onBlur();
+                  }}
                   onKeyDown={(e) => clearTypingContextOnKeyDown(e, ctx)}
                 />
               </motion.div>
@@ -962,6 +997,7 @@ const GridData = ({
   const [wordList] = useAtom(word_list_atom);
   const cols = grid_dimensions[1];
   const [lipi_lekhika_active] = useAtom(lipi_lekhika_active_atom);
+  const historyField = useHistoryTextField();
 
   const occupiedCellsStrList = (() => {
     if (gridData.length === 0 || wordList.length === 0) {
@@ -1020,7 +1056,11 @@ const GridData = ({
                   lipi_lekhika_active
                 )
               }
-              onBlur={() => ctx.clearContext()}
+              onFocus={historyField.onFocus}
+              onBlur={() => {
+                ctx.clearContext();
+                historyField.onBlur();
+              }}
               onKeyDown={(e) => clearTypingContextOnKeyDown(e, ctx)}
             />
           ))
@@ -1071,6 +1111,7 @@ const ListedSwitch = ({ slug }: { slug: string }) => {
 const Description = () => {
   const [description, setDescription] = useAtom(description_atom);
   const [lipi_lekhika_active] = useAtom(lipi_lekhika_active_atom);
+  const historyField = useHistoryTextField();
 
   const ctx = createTypingContext(BASE_SCRIPT);
 
@@ -1090,7 +1131,11 @@ const Description = () => {
               lipi_lekhika_active
             )
           }
-          onBlur={() => ctx.clearContext()}
+          onFocus={historyField.onFocus}
+          onBlur={() => {
+            ctx.clearContext();
+            historyField.onBlur();
+          }}
           onKeyDown={(e) => clearTypingContextOnKeyDown(e, ctx)}
           placeholder="Enter a description for the puzzle..."
           required
@@ -1107,17 +1152,10 @@ const SaveButton = ({ word_puzzle }: { word_puzzle: Puzzle }) => {
   const [gridData] = useAtom(grid_data_atom);
   const [attachments, setAttachments] = useAtom(attachments_atom);
   const [image_id] = useAtom(image_id_atom);
-  const [image_baseline, setImageBaseline] = useAtom(image_baseline_atom);
-  const initialRef = useRef({
-    title: word_puzzle.title,
-    wordList: word_puzzle.word_list,
-    gridData: word_puzzle.grid_data,
-    listed: word_puzzle.listed,
-    description: word_puzzle.description,
-    attachments: word_puzzle.attachments
-  });
+  const [, setImageBaseline] = useAtom(image_baseline_atom);
   const [listed] = useAtom(listed_atom);
   const [description] = useAtom(description_atom);
+  const { markSaved } = useEditorHistoryActions();
 
   const router = useRouter();
 
@@ -1141,15 +1179,8 @@ const SaveButton = ({ word_puzzle }: { word_puzzle: Puzzle }) => {
           setAttachments(updatedAttachments);
         }
 
-        initialRef.current = {
-          title,
-          wordList,
-          gridData,
-          listed,
-          description,
-          attachments: updatedAttachments
-        };
         setImageBaseline(image_id);
+        markSaved();
 
         // Clear React Query cache for the puzzle carousel
         void queryClient.invalidateQueries({ queryKey: ['listed_puzzles_carousel'] });
@@ -1183,18 +1214,6 @@ const SaveButton = ({ word_puzzle }: { word_puzzle: Puzzle }) => {
       toast.error('Failed to delete puzzle');
     }
   });
-
-  const isEdited = useMemo(() => {
-    return (
-      title !== initialRef.current.title ||
-      JSON.stringify(wordList) !== JSON.stringify(initialRef.current.wordList) ||
-      JSON.stringify(gridData) !== JSON.stringify(initialRef.current.gridData) ||
-      listed !== initialRef.current.listed ||
-      description !== initialRef.current.description ||
-      JSON.stringify(attachments) !== JSON.stringify(initialRef.current.attachments) ||
-      image_id !== image_baseline
-    );
-  }, [title, wordList, gridData, listed, description, attachments, image_id, image_baseline]);
 
   const handleSave = () => {
     if (!description.trim()) {
@@ -1232,56 +1251,34 @@ const SaveButton = ({ word_puzzle }: { word_puzzle: Puzzle }) => {
   };
 
   return (
-    <div className="mx-2 mt-2 flex items-center justify-between sm:mx-4">
-      <AlertDialog>
-        <AlertDialogTrigger
-          render={
-            <Button
-              disabled={!isEdited || update_word_puzzle_mut.isPending}
-              className="flex text-lg"
-              variant={'outline'}
-            />
-          }
-        >
-          <FiSave className="text-lg" /> {!update_word_puzzle_mut.isPending ? 'Save' : 'Saving...'}
-        </AlertDialogTrigger>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Confirm Save</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to save your changes?
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleSave}>Confirm</AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+    <>
+      <EditorActionDock onSave={handleSave} isSaving={update_word_puzzle_mut.isPending} />
 
-      <AlertDialog>
-        <AlertDialogTrigger
-          render={<Button className="flex gap-1 px-1 py-0 text-sm" variant="destructive" />}
-        >
-          <MdDeleteOutline className="text-base" />
-          Delete
-        </AlertDialogTrigger>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Confirm Delete</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete this puzzle? This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDelete} className="bg-red-500 hover:bg-red-400">
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </div>
+      <div className="mx-2 mt-2 flex items-center justify-end sm:mx-4">
+        <AlertDialog>
+          <AlertDialogTrigger
+            render={<Button className="flex gap-1 px-1 py-0 text-sm" variant="destructive" />}
+          >
+            <MdDeleteOutline className="text-base" />
+            Delete
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Confirm Delete</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete this puzzle? This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={handleDelete} className="bg-red-500 hover:bg-red-400">
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </>
   );
 };
 
@@ -1292,6 +1289,7 @@ const PuzzleImageSection = ({ word_puzzle }: { word_puzzle: Puzzle }) => {
   const [title] = useAtom(title_atom);
   const [description] = useAtom(description_atom);
   const [wordList] = useAtom(word_list_atom);
+  const { acceptKeysAsSaved } = useEditorHistoryActions();
 
   return (
     <PuzzleCardImageSection
@@ -1304,7 +1302,10 @@ const PuzzleImageSection = ({ word_puzzle }: { word_puzzle: Puzzle }) => {
       imageInfo={image_info}
       onImageIdChange={setImageId}
       onImageInfoChange={setImageInfo}
-      onImageBaselineChange={setImageBaseline}
+      onImageBaselineChange={(id) => {
+        setImageBaseline(id);
+        acceptKeysAsSaved('image_id', 'image_info');
+      }}
     />
   );
 };

--- a/src/components/pages/padavali/ViewEditPuzzle.tsx
+++ b/src/components/pages/padavali/ViewEditPuzzle.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { z } from 'zod';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -1155,7 +1155,11 @@ const SaveButton = ({ word_puzzle }: { word_puzzle: Puzzle }) => {
   const [, setImageBaseline] = useAtom(image_baseline_atom);
   const [listed] = useAtom(listed_atom);
   const [description] = useAtom(description_atom);
-  const { markSaved } = useEditorHistoryActions();
+  const { beginSave, markSaved } = useEditorHistoryActions();
+  const saveSnapRef = useRef<{
+    attachments: Puzzle['attachments'];
+    image_id: number | null;
+  } | null>(null);
 
   const router = useRouter();
 
@@ -1164,14 +1168,18 @@ const SaveButton = ({ word_puzzle }: { word_puzzle: Puzzle }) => {
       if (data.success) {
         toast.success('Puzzle updated successfully');
 
+        const submitted = saveSnapRef.current;
+        const baseAttachments = submitted?.attachments ?? attachments;
+        const savedImageId = submitted?.image_id ?? image_id;
+
         const { newly_added_index_ids } = data;
         const updatedAttachments =
           newly_added_index_ids.length > 0
-            ? attachments.map((val, i) => {
+            ? baseAttachments.map((val, i) => {
                 const elm = newly_added_index_ids.find(({ index }) => index === i);
                 return elm ? { ...val, id: elm.id } : val;
               })
-            : attachments;
+            : baseAttachments;
 
         if (newly_added_index_ids.length > 0) {
           // after update for the newly added attachemnts filling
@@ -1179,8 +1187,11 @@ const SaveButton = ({ word_puzzle }: { word_puzzle: Puzzle }) => {
           setAttachments(updatedAttachments);
         }
 
-        setImageBaseline(image_id);
-        markSaved();
+        setImageBaseline(savedImageId);
+        markSaved(
+          newly_added_index_ids.length > 0 ? { attachments: updatedAttachments } : undefined
+        );
+        saveSnapRef.current = null;
 
         // Clear React Query cache for the puzzle carousel
         void queryClient.invalidateQueries({ queryKey: ['listed_puzzles_carousel'] });
@@ -1192,6 +1203,7 @@ const SaveButton = ({ word_puzzle }: { word_puzzle: Puzzle }) => {
       }
     },
     onError() {
+      saveSnapRef.current = null;
       toast.error('Failed to update puzzle, check the entered data');
     }
   });
@@ -1236,6 +1248,8 @@ const SaveButton = ({ word_puzzle }: { word_puzzle: Puzzle }) => {
     } satisfies z.infer<typeof puzzle_update_input_schema>;
     const parse = puzzle_update_input_schema.safeParse(data);
     if (parse.success) {
+      beginSave();
+      saveSnapRef.current = { attachments, image_id };
       update_word_puzzle_mut.mutate(parse.data);
     } else {
       console.log(parse.error);
@@ -1289,7 +1303,6 @@ const PuzzleImageSection = ({ word_puzzle }: { word_puzzle: Puzzle }) => {
   const [title] = useAtom(title_atom);
   const [description] = useAtom(description_atom);
   const [wordList] = useAtom(word_list_atom);
-  const { acceptKeysAsSaved } = useEditorHistoryActions();
 
   return (
     <PuzzleCardImageSection
@@ -1302,10 +1315,7 @@ const PuzzleImageSection = ({ word_puzzle }: { word_puzzle: Puzzle }) => {
       imageInfo={image_info}
       onImageIdChange={setImageId}
       onImageInfoChange={setImageInfo}
-      onImageBaselineChange={(id) => {
-        setImageBaseline(id);
-        acceptKeysAsSaved('image_id', 'image_info');
-      }}
+      onImageBaselineChange={setImageBaseline}
     />
   );
 };

--- a/src/components/pages/padavali/ViewEditPuzzle.tsx
+++ b/src/components/pages/padavali/ViewEditPuzzle.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { z } from 'zod';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -995,9 +995,10 @@ const GridData = ({
 }) => {
   const [gridData, setGridData] = useAtom(grid_data_atom);
   const [wordList] = useAtom(word_list_atom);
-  const cols = grid_dimensions[1];
+  const [rows, cols] = grid_dimensions;
   const [lipi_lekhika_active] = useAtom(lipi_lekhika_active_atom);
   const historyField = useHistoryTextField();
+  const gridRef = useRef<HTMLDivElement>(null);
 
   const occupiedCellsStrList = (() => {
     if (gridData.length === 0 || wordList.length === 0) {
@@ -1023,6 +1024,40 @@ const GridData = ({
 
   const ctx = createTypingContext(BASE_SCRIPT);
 
+  const focusCellInput = (r: number, c: number) => {
+    const el = gridRef.current?.querySelector<HTMLInputElement>(
+      `input[data-grid-r="${r}"][data-grid-c="${c}"]`
+    );
+    if (!el) return false;
+    el.focus();
+    el.select();
+    return true;
+  };
+
+  const moveFocus = (r: number, c: number, dRow: number, dCol: number) => {
+    const nextR = r + dRow;
+    const nextC = c + dCol;
+    if (nextR < 0 || nextC < 0 || nextR >= rows || nextC >= cols) return;
+    focusCellInput(nextR, nextC);
+  };
+
+  const handleCellKeyDown = (r: number, c: number, e: KeyboardEvent<HTMLInputElement>) => {
+    clearTypingContextOnKeyDown(e, ctx);
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      moveFocus(r, c, 0, -1);
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      moveFocus(r, c, 0, 1);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      moveFocus(r, c, -1, 0);
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      moveFocus(r, c, 1, 0);
+    }
+  };
+
   const getCellClassName = (r: number, c: number) => {
     const isOccupied = occupiedCellsStrList.has(`${r},${c}`);
     return `rounded text-center transition-all duration-200 ${
@@ -1035,7 +1070,11 @@ const GridData = ({
   return (
     <div>
       <Label className="mb-2 block text-lg font-semibold">Grid</Label>
+      <p className="mb-2 hidden text-xs text-muted-foreground/80 sm:block">
+        Navigate the grid with the arrow keys (↑ ↓ ← →)
+      </p>
       <div
+        ref={gridRef}
         className="md:3/5 grid w-full gap-1 sm:w-4/5 md:w-3/5 lg:w-2/5"
         style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
       >
@@ -1044,6 +1083,8 @@ const GridData = ({
             <Input
               key={`${r}-${c}`}
               type="text"
+              data-grid-r={r}
+              data-grid-c={c}
               className={getCellClassName(r, c)}
               minLength={1}
               value={cell}
@@ -1061,7 +1102,7 @@ const GridData = ({
                 ctx.clearContext();
                 historyField.onBlur();
               }}
-              onKeyDown={(e) => clearTypingContextOnKeyDown(e, ctx)}
+              onKeyDown={(e) => handleCellKeyDown(r, c, e)}
             />
           ))
         )}

--- a/src/components/pages/puzzle/EditorActionDock.tsx
+++ b/src/components/pages/puzzle/EditorActionDock.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useEffect } from 'react';
+import { motion } from 'framer-motion';
+import { FiSave } from 'react-icons/fi';
+import { Redo2, Undo2 } from 'lucide-react';
+import { Button } from '~/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger
+} from '~/components/ui/alert-dialog';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '~/components/ui/tooltip';
+import { cn } from '~/lib/utils';
+import { useEditorHistoryActions, useEditorHistoryState } from '~/hooks/useEditorHistory';
+import { useUnsavedChangesGuard } from '~/hooks/useUnsavedChangesGuard';
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  return target.isContentEditable;
+}
+
+function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /Mac|iPhone|iPad|iPod/i.test(navigator.platform || navigator.userAgent);
+}
+
+type EditorActionDockProps = {
+  onSave: () => void;
+  isSaving?: boolean;
+  className?: string;
+};
+
+export function EditorActionDock({ onSave, isSaving = false, className }: EditorActionDockProps) {
+  const { undo, redo } = useEditorHistoryActions();
+  const { canUndo, canRedo, isDirty, changeCount } = useEditorHistoryState();
+
+  useUnsavedChangesGuard(isDirty);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (isEditableTarget(e.target)) return;
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod) return;
+
+      const key = e.key.toLowerCase();
+      if (key === 'z' && e.shiftKey) {
+        e.preventDefault();
+        redo();
+        return;
+      }
+      if (key === 'z') {
+        e.preventDefault();
+        undo();
+        return;
+      }
+      if (key === 'y' && !e.metaKey) {
+        e.preventDefault();
+        redo();
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [undo, redo]);
+
+  const modLabel = isMacPlatform() ? '⌘' : 'Ctrl';
+  const statusLabel = !isDirty
+    ? 'All changes saved'
+    : changeCount > 0
+      ? `${changeCount} unsaved change${changeCount === 1 ? '' : 's'}`
+      : 'Unsaved changes';
+
+  return (
+    <div
+      className={cn(
+        'pointer-events-none fixed inset-x-0 bottom-4 z-50 flex justify-center px-3 pb-[env(safe-area-inset-bottom)]',
+        className
+      )}
+    >
+      <TooltipProvider delay={200}>
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.18 }}
+          className={cn(
+            'pointer-events-auto flex max-w-full items-center gap-1.5 rounded-full border border-border/70',
+            'bg-card/95 px-2 py-1.5 shadow-lg backdrop-blur-md',
+            'dark:border-white/10 dark:bg-slate-900/90'
+          )}
+        >
+          <div className="flex min-w-0 items-center gap-2 px-2">
+            <span
+              className={cn(
+                'size-2 shrink-0 rounded-full',
+                isDirty ? 'animate-pulse bg-amber-500' : 'bg-emerald-500'
+              )}
+              aria-hidden
+            />
+            <span className="truncate text-xs font-medium text-muted-foreground sm:text-sm">
+              <span className="sm:hidden">
+                {isDirty ? (changeCount > 0 ? String(changeCount) : '•') : '✓'}
+              </span>
+              <span className="hidden sm:inline">{statusLabel}</span>
+            </span>
+          </div>
+
+          <div className="h-5 w-px shrink-0 bg-border/80" aria-hidden />
+
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant="ghost"
+                  disabled={!canUndo}
+                  onClick={() => undo()}
+                  aria-label="Undo"
+                  className="rounded-full"
+                />
+              }
+            >
+              <Undo2 className="size-4" />
+            </TooltipTrigger>
+            <TooltipContent side="top">Undo ({modLabel}+Z)</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant="ghost"
+                  disabled={!canRedo}
+                  onClick={() => redo()}
+                  aria-label="Redo"
+                  className="rounded-full"
+                />
+              }
+            >
+              <Redo2 className="size-4" />
+            </TooltipTrigger>
+            <TooltipContent side="top">Redo ({modLabel}+Shift+Z)</TooltipContent>
+          </Tooltip>
+
+          <div className="h-5 w-px shrink-0 bg-border/80" aria-hidden />
+
+          <AlertDialog>
+            <AlertDialogTrigger
+              render={
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={!isDirty || isSaving}
+                  className="gap-1.5 rounded-full px-3"
+                  aria-label="Save changes"
+                />
+              }
+            >
+              <FiSave className="size-3.5" />
+              <span className="hidden sm:inline">{isSaving ? 'Saving…' : 'Save'}</span>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Confirm Save</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Are you sure you want to save your changes?
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={onSave}>Confirm</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </motion.div>
+      </TooltipProvider>
+    </div>
+  );
+}

--- a/src/hooks/useEditorHistory.tsx
+++ b/src/hooks/useEditorHistory.tsx
@@ -25,8 +25,14 @@ type HistoryActions = {
   commit(): void;
   beginTyping(): void;
   endTyping(): void;
-  markSaved(): void;
-  /** Copy current values of the given keys into the saved baseline (e.g. auto-approved image). */
+  /** Freeze the current snapshot as the in-flight save baseline. */
+  beginSave(): void;
+  /**
+   * Mark the beginSave() snapshot (or current, if none) as saved.
+   * Optional patch overlays fields reconciled after the server response (e.g. attachment ids).
+   */
+  markSaved(patch?: Record<string, unknown>): void;
+  /** Copy current values of the given keys into the saved baseline (e.g. after persisted image save). */
   acceptKeysAsSaved(...keys: string[]): void;
 };
 
@@ -87,6 +93,7 @@ export function EditorHistoryProvider<M extends AtomMap>({
   const savedStackDepthRef = useRef(0);
   const commitScheduledRef = useRef(false);
   const didInitRef = useRef(false);
+  const pendingSaveRef = useRef<SnapshotOf<M> | null>(null);
   const listenersRef = useRef(new Set<() => void>());
   // Cached state so useSyncExternalStore can bail out on referential equality.
   const stateCacheRef = useRef<HistoryState>(EMPTY_STATE);
@@ -156,6 +163,9 @@ export function EditorHistoryProvider<M extends AtomMap>({
     }
 
     if (serialize(current) === serialize(last)) {
+      // Comparable-equal but raw snapshot may still differ (e.g. client-only word ids).
+      // Refresh lastCommitted so later commits don't push a no-op undo entry.
+      lastCommittedRef.current = cloneSnapshot(current);
       notify();
       return;
     }
@@ -252,10 +262,20 @@ export function EditorHistoryProvider<M extends AtomMap>({
           commitNow();
         }
       },
-      markSaved() {
-        const current = takeSnapshot();
-        savedBaselineRef.current = cloneSnapshot(current);
-        lastCommittedRef.current = cloneSnapshot(current);
+      beginSave() {
+        pendingSaveRef.current = cloneSnapshot(takeSnapshot());
+      },
+      markSaved(patch?: Record<string, unknown>) {
+        const base = pendingSaveRef.current ?? takeSnapshot();
+        pendingSaveRef.current = null;
+        const next = cloneSnapshot(base);
+        if (patch) {
+          for (const [key, value] of Object.entries(patch)) {
+            (next as Record<string, unknown>)[key] = cloneSnapshot(value);
+          }
+        }
+        savedBaselineRef.current = next;
+        lastCommittedRef.current = cloneSnapshot(next);
         savedStackDepthRef.current = undoStackRef.current.length;
         notify();
       },

--- a/src/hooks/useEditorHistory.tsx
+++ b/src/hooks/useEditorHistory.tsx
@@ -1,0 +1,347 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+  type ReactNode
+} from 'react';
+import { useStore, type PrimitiveAtom } from 'jotai';
+
+type AtomMap = Record<string, PrimitiveAtom<any>>;
+type SnapshotOf<M extends AtomMap> = {
+  [K in keyof M]: M[K] extends PrimitiveAtom<infer V> ? V : never;
+};
+
+const MAX_STACK = 100;
+
+type HistoryActions = {
+  undo(): void;
+  redo(): void;
+  commit(): void;
+  beginTyping(): void;
+  endTyping(): void;
+  markSaved(): void;
+  /** Copy current values of the given keys into the saved baseline (e.g. auto-approved image). */
+  acceptKeysAsSaved(...keys: string[]): void;
+};
+
+type HistoryState = {
+  canUndo: boolean;
+  canRedo: boolean;
+  isDirty: boolean;
+  changeCount: number;
+};
+
+type HistoryContextValue = {
+  actions: HistoryActions;
+  subscribe: (listener: () => void) => () => void;
+  getState: () => HistoryState;
+  getServerSnapshot: () => HistoryState;
+};
+
+const HistoryContext = createContext<HistoryContextValue | null>(null);
+
+const EMPTY_STATE: HistoryState = {
+  canUndo: false,
+  canRedo: false,
+  isDirty: false,
+  changeCount: 0
+};
+
+function cloneSnapshot<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function serializeSnapshot(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+export function EditorHistoryProvider<M extends AtomMap>({
+  atoms,
+  comparable,
+  children
+}: {
+  atoms: M;
+  comparable?: (snapshot: SnapshotOf<M>) => unknown;
+  children: ReactNode;
+}) {
+  const store = useStore();
+  // Stable list of [key, atom] for the lifetime of this atoms object.
+  const atomEntriesRef = useRef(Object.entries(atoms) as [keyof M & string, M[keyof M]][]);
+  atomEntriesRef.current = Object.entries(atoms) as [keyof M & string, M[keyof M]][];
+
+  const comparableRef = useRef(comparable);
+  comparableRef.current = comparable;
+
+  const lastCommittedRef = useRef<SnapshotOf<M> | null>(null);
+  const savedBaselineRef = useRef<SnapshotOf<M> | null>(null);
+  const undoStackRef = useRef<SnapshotOf<M>[]>([]);
+  const redoStackRef = useRef<SnapshotOf<M>[]>([]);
+  const typingDepthRef = useRef(0);
+  const isRestoringRef = useRef(false);
+  const savedStackDepthRef = useRef(0);
+  const commitScheduledRef = useRef(false);
+  const didInitRef = useRef(false);
+  const listenersRef = useRef(new Set<() => void>());
+  // Cached state so useSyncExternalStore can bail out on referential equality.
+  const stateCacheRef = useRef<HistoryState>(EMPTY_STATE);
+
+  const takeSnapshot = useCallback((): SnapshotOf<M> => {
+    const snap = {} as SnapshotOf<M>;
+    for (const [key, atom] of atomEntriesRef.current) {
+      snap[key] = store.get(atom) as SnapshotOf<M>[typeof key];
+    }
+    return snap;
+  }, [store]);
+
+  const restoreSnapshot = useCallback(
+    (snapshot: SnapshotOf<M>) => {
+      for (const [key, atom] of atomEntriesRef.current) {
+        store.set(atom, cloneSnapshot(snapshot[key]));
+      }
+    },
+    [store]
+  );
+
+  const serialize = useCallback((snapshot: SnapshotOf<M>) => {
+    const comparableFn = comparableRef.current;
+    return serializeSnapshot(comparableFn ? comparableFn(snapshot) : snapshot);
+  }, []);
+
+  const computeState = useCallback((): HistoryState => {
+    const saved = savedBaselineRef.current;
+    if (!saved) return EMPTY_STATE;
+    const current = takeSnapshot();
+    return {
+      canUndo: undoStackRef.current.length > 0,
+      canRedo: redoStackRef.current.length > 0,
+      isDirty: serialize(current) !== serialize(saved),
+      changeCount: Math.max(0, undoStackRef.current.length - savedStackDepthRef.current)
+    };
+  }, [serialize, takeSnapshot]);
+
+  const notify = useCallback(() => {
+    stateCacheRef.current = computeState();
+    for (const listener of listenersRef.current) listener();
+  }, [computeState]);
+
+  const getState = useCallback(() => stateCacheRef.current, []);
+  const getServerSnapshot = useCallback(() => EMPTY_STATE, []);
+
+  const subscribe = useCallback((listener: () => void) => {
+    listenersRef.current.add(listener);
+    return () => {
+      listenersRef.current.delete(listener);
+    };
+  }, []);
+
+  const commitNow = useCallback(() => {
+    if (isRestoringRef.current) return;
+    if (typingDepthRef.current > 0) return;
+
+    const current = takeSnapshot();
+    const last = lastCommittedRef.current;
+    if (!last) {
+      lastCommittedRef.current = cloneSnapshot(current);
+      if (!savedBaselineRef.current) {
+        savedBaselineRef.current = cloneSnapshot(current);
+      }
+      notify();
+      return;
+    }
+
+    if (serialize(current) === serialize(last)) {
+      notify();
+      return;
+    }
+
+    undoStackRef.current.push(cloneSnapshot(last));
+    if (undoStackRef.current.length > MAX_STACK) {
+      undoStackRef.current.shift();
+      savedStackDepthRef.current = Math.max(0, savedStackDepthRef.current - 1);
+    }
+    lastCommittedRef.current = cloneSnapshot(current);
+    redoStackRef.current = [];
+    notify();
+  }, [notify, serialize, takeSnapshot]);
+
+  const scheduleCommit = useCallback(() => {
+    if (isRestoringRef.current || typingDepthRef.current > 0) return;
+    if (commitScheduledRef.current) return;
+    commitScheduledRef.current = true;
+    queueMicrotask(() => {
+      commitScheduledRef.current = false;
+      commitNow();
+    });
+  }, [commitNow]);
+
+  // Keep latest commit helpers in refs so the atom-subscription effect stays mounted once.
+  const scheduleCommitRef = useRef(scheduleCommit);
+  scheduleCommitRef.current = scheduleCommit;
+  const notifyRef = useRef(notify);
+  notifyRef.current = notify;
+  const takeSnapshotRef = useRef(takeSnapshot);
+  takeSnapshotRef.current = takeSnapshot;
+
+  // Seed baselines once, then subscribe for the lifetime of this provider instance.
+  useEffect(() => {
+    if (!didInitRef.current) {
+      const initial = takeSnapshotRef.current();
+      lastCommittedRef.current = cloneSnapshot(initial);
+      savedBaselineRef.current = cloneSnapshot(initial);
+      undoStackRef.current = [];
+      redoStackRef.current = [];
+      savedStackDepthRef.current = 0;
+      didInitRef.current = true;
+      notifyRef.current();
+    }
+
+    const unsubscribers = atomEntriesRef.current.map(([, atom]) =>
+      store.sub(atom, () => {
+        if (isRestoringRef.current) return;
+        // Refresh dirty UI immediately; commit only when not mid-typing.
+        notifyRef.current();
+        if (typingDepthRef.current > 0) return;
+        scheduleCommitRef.current();
+      })
+    );
+
+    return () => {
+      for (const unsub of unsubscribers) unsub();
+    };
+  }, [store]);
+
+  const actions = useMemo<HistoryActions>(
+    () => ({
+      undo() {
+        if (undoStackRef.current.length === 0) return;
+        const current = takeSnapshot();
+        const previous = undoStackRef.current.pop()!;
+        redoStackRef.current.push(cloneSnapshot(current));
+        isRestoringRef.current = true;
+        restoreSnapshot(previous);
+        lastCommittedRef.current = cloneSnapshot(previous);
+        isRestoringRef.current = false;
+        notify();
+      },
+      redo() {
+        if (redoStackRef.current.length === 0) return;
+        const current = takeSnapshot();
+        const next = redoStackRef.current.pop()!;
+        undoStackRef.current.push(cloneSnapshot(current));
+        isRestoringRef.current = true;
+        restoreSnapshot(next);
+        lastCommittedRef.current = cloneSnapshot(next);
+        isRestoringRef.current = false;
+        notify();
+      },
+      commit() {
+        commitNow();
+      },
+      beginTyping() {
+        typingDepthRef.current += 1;
+      },
+      endTyping() {
+        typingDepthRef.current = Math.max(0, typingDepthRef.current - 1);
+        if (typingDepthRef.current === 0) {
+          commitNow();
+        }
+      },
+      markSaved() {
+        const current = takeSnapshot();
+        savedBaselineRef.current = cloneSnapshot(current);
+        lastCommittedRef.current = cloneSnapshot(current);
+        savedStackDepthRef.current = undoStackRef.current.length;
+        notify();
+      },
+      acceptKeysAsSaved(...keys: string[]) {
+        const current = takeSnapshot();
+        const baseline = savedBaselineRef.current;
+        const last = lastCommittedRef.current;
+        if (!baseline) {
+          savedBaselineRef.current = cloneSnapshot(current);
+          lastCommittedRef.current = cloneSnapshot(current);
+          notify();
+          return;
+        }
+        const nextBaseline = cloneSnapshot(baseline);
+        const nextLast = last ? cloneSnapshot(last) : cloneSnapshot(current);
+        for (const key of keys) {
+          if (key in current) {
+            const value = cloneSnapshot((current as Record<string, unknown>)[key]);
+            (nextBaseline as Record<string, unknown>)[key] = value;
+            (nextLast as Record<string, unknown>)[key] = value;
+          }
+        }
+        savedBaselineRef.current = nextBaseline;
+        lastCommittedRef.current = nextLast;
+        notify();
+      }
+    }),
+    [commitNow, notify, restoreSnapshot, takeSnapshot]
+  );
+
+  const value = useMemo<HistoryContextValue>(
+    () => ({ actions, subscribe, getState, getServerSnapshot }),
+    [actions, subscribe, getState, getServerSnapshot]
+  );
+
+  return <HistoryContext.Provider value={value}>{children}</HistoryContext.Provider>;
+}
+
+function useHistoryContext(): HistoryContextValue {
+  const ctx = useContext(HistoryContext);
+  if (!ctx) {
+    throw new Error('Editor history hooks must be used within EditorHistoryProvider');
+  }
+  return ctx;
+}
+
+export function useEditorHistoryActions(): HistoryActions {
+  return useHistoryContext().actions;
+}
+
+export function useEditorHistoryState(): HistoryState {
+  const { subscribe, getState, getServerSnapshot } = useHistoryContext();
+  return useSyncExternalStore(subscribe, getState, getServerSnapshot);
+}
+
+export function useHistoryTextField(): {
+  onFocus: () => void;
+  onBlur: () => void;
+} {
+  const { beginTyping, endTyping } = useEditorHistoryActions();
+  const focusedRef = useRef(false);
+
+  useEffect(
+    () => () => {
+      // Field unmounted while focused (list row removed, etc.) — balance typingDepth.
+      if (focusedRef.current) {
+        focusedRef.current = false;
+        endTyping();
+      }
+    },
+    [endTyping]
+  );
+
+  return useMemo(
+    () => ({
+      onFocus: () => {
+        if (focusedRef.current) return;
+        focusedRef.current = true;
+        beginTyping();
+      },
+      onBlur: () => {
+        if (!focusedRef.current) return;
+        focusedRef.current = false;
+        endTyping();
+      }
+    }),
+    [beginTyping, endTyping]
+  );
+}

--- a/src/hooks/useUnsavedChangesGuard.ts
+++ b/src/hooks/useUnsavedChangesGuard.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+const DEFAULT_MESSAGE =
+  'You have unsaved changes. Are you sure you want to leave? Your edits will be lost.';
+
+const GUARD_STATE = { __padavaliEditorUnsavedGuard: true } as const;
+
+function isGuardState(state: unknown): boolean {
+  return (
+    !!state &&
+    typeof state === 'object' &&
+    (state as { __padavaliEditorUnsavedGuard?: boolean }).__padavaliEditorUnsavedGuard === true
+  );
+}
+
+/**
+ * Browser-level leave guard: blocks reload/close via `beforeunload`, and
+ * intercepts back/forward via `popstate` + native `confirm`.
+ * Active only while `enabled` is true.
+ */
+export function useUnsavedChangesGuard(enabled: boolean, message: string = DEFAULT_MESSAGE) {
+  const messageRef = useRef(message);
+  messageRef.current = message;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let sentinelPushed = false;
+
+    const pushSentinel = () => {
+      if (sentinelPushed) return;
+      window.history.pushState(GUARD_STATE, '', window.location.href);
+      sentinelPushed = true;
+    };
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+
+    const handlePopState = () => {
+      // Browser already popped our sentinel (or navigated). Treat as leave attempt.
+      sentinelPushed = false;
+      const confirmLeave = window.confirm(messageRef.current);
+      if (!confirmLeave) {
+        pushSentinel();
+        return;
+      }
+      // Proceed with the back navigation past the real page entry.
+      window.history.back();
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('popstate', handlePopState);
+    pushSentinel();
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('popstate', handlePopState);
+      // Drop the duplicate same-URL sentinel without leaving the editor.
+      if (sentinelPushed && isGuardState(window.history.state)) {
+        sentinelPushed = false;
+        window.history.back();
+      }
+    };
+  }, [enabled]);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added undo and redo controls to crossword and puzzle editors.
  * Added keyboard shortcuts for undo and redo.
  * Added an editor action dock with save status and confirmation.
  * Added unsaved-change protection when leaving or closing an editor.
* **Improvements**
  * Improved tracking of changes while editing text, clues, words, grid cells, and image details.
  * Save actions now clearly finalize the current edit history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->