### PR TITLE
feat: Add Reveal feature for Padajala

### DIFF
--- a/src/components/pages/cross_word/CrossWordGame/CluePanel.tsx
+++ b/src/components/pages/cross_word/CrossWordGame/CluePanel.tsx
@@ -3,15 +3,10 @@
 import { useEffect, useEffectEvent, useRef, useState } from 'react';
 import { useAtomValue } from 'jotai';
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion';
-import { AlertCircle, CheckCircle2, Eye, Sparkles } from 'lucide-react';
+import { AlertCircle, CheckCircle2, Sparkles } from 'lucide-react';
 import { cn } from '~/lib/utils';
 import { Popover, PopoverContent, PopoverTrigger } from '~/components/ui/popover';
-import {
-  active_focus_atom,
-  MAX_WORD_REVEALS,
-  numbered_entries_atom,
-  solved_entry_ids_atom
-} from './game_state';
+import { active_focus_atom, numbered_entries_atom, solved_entry_ids_atom } from './game_state';
 import type { useCrossWordGame } from './useCrossWordGame';
 import type { MoreHintsQuery } from './useMoreHints';
 import type { NumberedEntry } from '~/util/cross_word/game_model';
@@ -42,176 +37,13 @@ function sortClues(entries: NumberedEntry[], solvedIds: string[]) {
   });
 }
 
-function RevealPips({ left, total }: { left: number; total: number }) {
-  return (
-    <div className="flex items-center gap-1" aria-hidden>
-      {Array.from({ length: total }, (_, i) => {
-        const available = i < left;
-        return (
-          <span
-            key={i}
-            className={cn(
-              'size-1.5 rounded-full transition-colors',
-              available
-                ? 'bg-amber-500 shadow-[0_0_4px_oklch(0.75_0.16_70/0.55)] dark:bg-amber-400'
-                : 'bg-transparent ring-1 ring-amber-400/40 dark:ring-amber-500/35'
-            )}
-          />
-        );
-      })}
-    </div>
-  );
-}
-
-function RevealWordSection({
-  entryId,
-  game,
-  onConfirmReveal
-}: {
-  entryId: string;
-  game: ReturnType<typeof useCrossWordGame>;
-  onConfirmReveal: () => void;
-}) {
-  const [confirming, setConfirming] = useState(false);
-  const revealsLeft = game.revealsLeft;
-  const busy = game.revealingEntryId !== null;
-  const spent = revealsLeft <= 0;
-
-  return (
-    <div className="flex flex-col gap-2 border-t border-border/50 pt-2.5">
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
-          <Eye className="size-3.5 text-amber-600 dark:text-amber-400" />
-          Reveal word
-        </div>
-        <div className="flex items-center justify-center gap-1.5 space-x-1">
-          <RevealPips left={revealsLeft} total={MAX_WORD_REVEALS} />
-          <span className="text-[9px] font-bold tracking-wide text-amber-700/80 uppercase dark:text-amber-300/80">
-            {spent ? 'None left' : `${revealsLeft} of ${MAX_WORD_REVEALS}`}
-          </span>
-        </div>
-      </div>
-
-      <AnimatePresence mode="wait" initial={false}>
-        {spent ? (
-          <motion.p
-            key="spent"
-            initial={{ opacity: 0, y: 4 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -4 }}
-            transition={{ duration: 0.15 }}
-            className="text-[11px] leading-snug text-muted-foreground"
-          >
-            No reveals left this session.
-          </motion.p>
-        ) : confirming ? (
-          <motion.div
-            key="confirm"
-            initial={{ opacity: 0, y: 4 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -4 }}
-            transition={{ duration: 0.18 }}
-            className="flex flex-col gap-2"
-          >
-            <p className="text-[11px] leading-snug text-muted-foreground">
-              Use 1 of your {MAX_WORD_REVEALS} reveals on this word?
-            </p>
-            <div className="flex items-center justify-end gap-1.5">
-              <button
-                type="button"
-                disabled={busy}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setConfirming(false);
-                }}
-                onPointerDown={(e) => e.stopPropagation()}
-                className={cn(
-                  'rounded-md px-2.5 py-1 text-[11px] font-semibold',
-                  'text-muted-foreground transition-colors',
-                  'hover:bg-muted/70 hover:text-foreground',
-                  'disabled:pointer-events-none disabled:opacity-40'
-                )}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                disabled={busy}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onConfirmReveal();
-                  game.revealEntry(entryId);
-                }}
-                onPointerDown={(e) => e.stopPropagation()}
-                className={cn(
-                  'rounded-md px-2.5 py-1 text-[11px] font-semibold text-white',
-                  'bg-linear-to-r from-orange-600 to-amber-700',
-                  'shadow-sm shadow-orange-600/30 transition-all',
-                  'hover:from-orange-500 hover:to-amber-600 hover:brightness-110',
-                  'active:scale-[0.97]',
-                  'dark:from-orange-700 dark:to-amber-800 dark:shadow-orange-900/40',
-                  'dark:hover:from-orange-600 dark:hover:to-amber-700',
-                  'disabled:pointer-events-none disabled:opacity-40'
-                )}
-              >
-                Reveal
-              </button>
-            </div>
-          </motion.div>
-        ) : (
-          <motion.div
-            key="idle"
-            initial={{ opacity: 0, y: 4 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -4 }}
-            transition={{ duration: 0.18 }}
-          >
-            <button
-              type="button"
-              disabled={busy || !game.started || game.completed}
-              onClick={(e) => {
-                e.stopPropagation();
-                setConfirming(true);
-              }}
-              onPointerDown={(e) => e.stopPropagation()}
-              className={cn(
-                'flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-1.5',
-                'text-[11px] font-semibold text-white shadow-md',
-                'bg-linear-to-r from-orange-600 to-amber-700',
-                'shadow-orange-600/30 transition-all',
-                'hover:from-orange-500 hover:to-amber-600 hover:shadow-lg',
-                'active:scale-[0.98]',
-                'dark:from-orange-700 dark:to-amber-800 dark:shadow-orange-900/40',
-                'dark:hover:from-orange-600 dark:hover:to-amber-700',
-                'disabled:pointer-events-none disabled:opacity-40'
-              )}
-            >
-              <Eye className="size-3.5" />
-              Reveal this word
-            </button>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
-  );
-}
-
-function MoreHintPopover({
-  entryId,
-  moreHints,
-  game
-}: {
-  entryId: string;
-  moreHints: MoreHintsQuery;
-  game: ReturnType<typeof useCrossWordGame>;
-}) {
+function MoreHintPopover({ entryId, moreHints }: { entryId: string; moreHints: MoreHintsQuery }) {
   const hint = moreHints.hintByEntryId[entryId];
   const { isLoading, isFetching, error, refetch } = moreHints;
   const pending = isLoading || (isFetching && !hint);
-  const [open, setOpen] = useState(false);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover>
       <PopoverTrigger
         type="button"
         aria-label="Show AI more hint"
@@ -286,15 +118,6 @@ function MoreHintPopover({
         ) : (
           <p className="text-xs text-muted-foreground">No extra hint available for this clue.</p>
         )}
-
-        {game.started && !game.completed ? (
-          <RevealWordSection
-            key={open ? 'open' : 'closed'}
-            entryId={entryId}
-            game={game}
-            onConfirmReveal={() => setOpen(false)}
-          />
-        ) : null}
       </PopoverContent>
     </Popover>
   );
@@ -495,7 +318,7 @@ export function CluePanel({ game, moreHints, className }: CluePanelProps) {
 
                   {active ? (
                     <div className="shrink-0 pt-1.5 pr-1.5">
-                      <MoreHintPopover entryId={entry.id} moreHints={moreHints} game={game} />
+                      <MoreHintPopover entryId={entry.id} moreHints={moreHints} />
                     </div>
                   ) : null}
                 </motion.li>

--- a/src/components/pages/cross_word/CrossWordGame/CluePanel.tsx
+++ b/src/components/pages/cross_word/CrossWordGame/CluePanel.tsx
@@ -3,10 +3,15 @@
 import { useEffect, useEffectEvent, useRef, useState } from 'react';
 import { useAtomValue } from 'jotai';
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion';
-import { AlertCircle, CheckCircle2, Sparkles } from 'lucide-react';
+import { AlertCircle, CheckCircle2, Eye, Sparkles } from 'lucide-react';
 import { cn } from '~/lib/utils';
 import { Popover, PopoverContent, PopoverTrigger } from '~/components/ui/popover';
-import { active_focus_atom, numbered_entries_atom, solved_entry_ids_atom } from './game_state';
+import {
+  active_focus_atom,
+  MAX_WORD_REVEALS,
+  numbered_entries_atom,
+  solved_entry_ids_atom
+} from './game_state';
 import type { useCrossWordGame } from './useCrossWordGame';
 import type { MoreHintsQuery } from './useMoreHints';
 import type { NumberedEntry } from '~/util/cross_word/game_model';
@@ -37,13 +42,176 @@ function sortClues(entries: NumberedEntry[], solvedIds: string[]) {
   });
 }
 
-function MoreHintPopover({ entryId, moreHints }: { entryId: string; moreHints: MoreHintsQuery }) {
+function RevealPips({ left, total }: { left: number; total: number }) {
+  return (
+    <div className="flex items-center gap-1" aria-hidden>
+      {Array.from({ length: total }, (_, i) => {
+        const available = i < left;
+        return (
+          <span
+            key={i}
+            className={cn(
+              'size-1.5 rounded-full transition-colors',
+              available
+                ? 'bg-amber-500 shadow-[0_0_4px_oklch(0.75_0.16_70/0.55)] dark:bg-amber-400'
+                : 'bg-transparent ring-1 ring-amber-400/40 dark:ring-amber-500/35'
+            )}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function RevealWordSection({
+  entryId,
+  game,
+  onConfirmReveal
+}: {
+  entryId: string;
+  game: ReturnType<typeof useCrossWordGame>;
+  onConfirmReveal: () => void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const revealsLeft = game.revealsLeft;
+  const busy = game.revealingEntryId !== null;
+  const spent = revealsLeft <= 0;
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-border/50 pt-2.5">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
+          <Eye className="size-3.5 text-amber-600 dark:text-amber-400" />
+          Reveal word
+        </div>
+        <div className="flex items-center justify-center gap-1.5 space-x-1">
+          <RevealPips left={revealsLeft} total={MAX_WORD_REVEALS} />
+          <span className="text-[9px] font-bold tracking-wide text-amber-700/80 uppercase dark:text-amber-300/80">
+            {spent ? 'None left' : `${revealsLeft} of ${MAX_WORD_REVEALS}`}
+          </span>
+        </div>
+      </div>
+
+      <AnimatePresence mode="wait" initial={false}>
+        {spent ? (
+          <motion.p
+            key="spent"
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.15 }}
+            className="text-[11px] leading-snug text-muted-foreground"
+          >
+            No reveals left this session.
+          </motion.p>
+        ) : confirming ? (
+          <motion.div
+            key="confirm"
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.18 }}
+            className="flex flex-col gap-2"
+          >
+            <p className="text-[11px] leading-snug text-muted-foreground">
+              Use 1 of your {MAX_WORD_REVEALS} reveals on this word?
+            </p>
+            <div className="flex items-center justify-end gap-1.5">
+              <button
+                type="button"
+                disabled={busy}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setConfirming(false);
+                }}
+                onPointerDown={(e) => e.stopPropagation()}
+                className={cn(
+                  'rounded-md px-2.5 py-1 text-[11px] font-semibold',
+                  'text-muted-foreground transition-colors',
+                  'hover:bg-muted/70 hover:text-foreground',
+                  'disabled:pointer-events-none disabled:opacity-40'
+                )}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onConfirmReveal();
+                  game.revealEntry(entryId);
+                }}
+                onPointerDown={(e) => e.stopPropagation()}
+                className={cn(
+                  'rounded-md px-2.5 py-1 text-[11px] font-semibold text-white',
+                  'bg-linear-to-r from-orange-600 to-amber-700',
+                  'shadow-sm shadow-orange-600/30 transition-all',
+                  'hover:from-orange-500 hover:to-amber-600 hover:brightness-110',
+                  'active:scale-[0.97]',
+                  'dark:from-orange-700 dark:to-amber-800 dark:shadow-orange-900/40',
+                  'dark:hover:from-orange-600 dark:hover:to-amber-700',
+                  'disabled:pointer-events-none disabled:opacity-40'
+                )}
+              >
+                Reveal
+              </button>
+            </div>
+          </motion.div>
+        ) : (
+          <motion.div
+            key="idle"
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.18 }}
+          >
+            <button
+              type="button"
+              disabled={busy || !game.started || game.completed}
+              onClick={(e) => {
+                e.stopPropagation();
+                setConfirming(true);
+              }}
+              onPointerDown={(e) => e.stopPropagation()}
+              className={cn(
+                'flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-1.5',
+                'text-[11px] font-semibold text-white shadow-md',
+                'bg-linear-to-r from-orange-600 to-amber-700',
+                'shadow-orange-600/30 transition-all',
+                'hover:from-orange-500 hover:to-amber-600 hover:shadow-lg',
+                'active:scale-[0.98]',
+                'dark:from-orange-700 dark:to-amber-800 dark:shadow-orange-900/40',
+                'dark:hover:from-orange-600 dark:hover:to-amber-700',
+                'disabled:pointer-events-none disabled:opacity-40'
+              )}
+            >
+              <Eye className="size-3.5" />
+              Reveal this word
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function MoreHintPopover({
+  entryId,
+  moreHints,
+  game
+}: {
+  entryId: string;
+  moreHints: MoreHintsQuery;
+  game: ReturnType<typeof useCrossWordGame>;
+}) {
   const hint = moreHints.hintByEntryId[entryId];
   const { isLoading, isFetching, error, refetch } = moreHints;
   const pending = isLoading || (isFetching && !hint);
+  const [open, setOpen] = useState(false);
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger
         type="button"
         aria-label="Show AI more hint"
@@ -118,6 +286,15 @@ function MoreHintPopover({ entryId, moreHints }: { entryId: string; moreHints: M
         ) : (
           <p className="text-xs text-muted-foreground">No extra hint available for this clue.</p>
         )}
+
+        {game.started && !game.completed ? (
+          <RevealWordSection
+            key={open ? 'open' : 'closed'}
+            entryId={entryId}
+            game={game}
+            onConfirmReveal={() => setOpen(false)}
+          />
+        ) : null}
       </PopoverContent>
     </Popover>
   );
@@ -318,7 +495,7 @@ export function CluePanel({ game, moreHints, className }: CluePanelProps) {
 
                   {active ? (
                     <div className="shrink-0 pt-1.5 pr-1.5">
-                      <MoreHintPopover entryId={entry.id} moreHints={moreHints} />
+                      <MoreHintPopover entryId={entry.id} moreHints={moreHints} game={game} />
                     </div>
                   ) : null}
                 </motion.li>

--- a/src/components/pages/cross_word/CrossWordGame/CrossWordCell.tsx
+++ b/src/components/pages/cross_word/CrossWordGame/CrossWordCell.tsx
@@ -15,6 +15,7 @@ type CrossWordCellProps = {
   inActiveWord: boolean;
   solved: boolean;
   justSolved: boolean;
+  revealed?: boolean;
   incorrect: boolean;
   disabled: boolean;
   onSelect: () => void;
@@ -31,6 +32,7 @@ export function CrossWordCell({
   inActiveWord,
   solved,
   justSolved,
+  revealed = false,
   incorrect,
   disabled,
   onSelect
@@ -53,6 +55,7 @@ export function CrossWordCell({
         selected && styles.cellSelected,
         incorrect && !solved && styles.cellIncorrectState,
         justSolved && styles.cellJustSolved,
+        revealed && !justSolved && styles.cellRevealed,
         incorrect && !solved && styles.cellIncorrect,
         disabled && 'cursor-default'
       )}

--- a/src/components/pages/cross_word/CrossWordGame/CrossWordGame.tsx
+++ b/src/components/pages/cross_word/CrossWordGame/CrossWordGame.tsx
@@ -293,6 +293,8 @@ export function CrossWordGame({
       if (target.closest('[role="grid"]')) return;
       if (target.closest('button')) return;
       if (target.closest('[data-slot="popover-content"]')) return;
+      if (target.closest('[data-slot="alert-dialog-content"]')) return;
+      if (target.closest('[data-slot="alert-dialog-overlay"]')) return;
       if (target.closest('[data-crossword-onscreen-kb="true"]')) return;
       if (target.closest(`[${CROSSWORD_KB_ATTR}="true"]`)) return;
 
@@ -418,7 +420,12 @@ export function CrossWordGame({
       ) : null}
 
       <div className="mb-3 flex flex-col items-center gap-3 sm:mb-4">
-        <GameProgress onReset={game.resetGame} />
+        <GameProgress
+          onReset={game.resetGame}
+          revealsLeft={game.revealsLeft}
+          revealingEntryId={game.revealingEntryId}
+          onReveal={game.revealEntry}
+        />
         <CompletionCelebration listed={listed} puzzleSlug={puzzleSlug} />
       </div>
 

--- a/src/components/pages/cross_word/CrossWordGame/CrossWordGameRoot.tsx
+++ b/src/components/pages/cross_word/CrossWordGame/CrossWordGameRoot.tsx
@@ -18,7 +18,10 @@ import {
   solved_entry_ids_atom,
   started_atom,
   active_focus_atom,
-  pending_navigation_url_atom
+  pending_navigation_url_atom,
+  reveals_used_atom,
+  revealing_entry_id_atom,
+  revealing_cells_atom
 } from './game_state';
 import {
   createEmptyPlayerGrid,
@@ -81,6 +84,9 @@ export default function CrossWordGameRoot({
     store.set(letter_inputs_atom, 0);
     store.set(incorrect_entry_attempts_atom, 0);
     store.set(pending_navigation_url_atom, null);
+    store.set(reveals_used_atom, 0);
+    store.set(revealing_entry_id_atom, null);
+    store.set(revealing_cells_atom, []);
     return store;
   }, [puzzle.id, puzzle]);
 

--- a/src/components/pages/cross_word/CrossWordGame/CrossWordGrid.tsx
+++ b/src/components/pages/cross_word/CrossWordGame/CrossWordGrid.tsx
@@ -9,6 +9,7 @@ import {
   incorrect_entry_ids_atom,
   numbered_entries_atom,
   puzzle_atom,
+  revealing_cells_atom,
   solved_entry_ids_atom
 } from './game_state';
 import { cellKey, getEntryCells, isBlockedCell, isFixedCell } from '~/util/cross_word/game_model';
@@ -30,6 +31,7 @@ export function CrossWordGrid({ game, onRequestKeyboard }: CrossWordGridProps) {
   const focus = useAtomValue(active_focus_atom);
   const solvedIds = useAtomValue(solved_entry_ids_atom);
   const incorrectIds = useAtomValue(incorrect_entry_ids_atom);
+  const revealingCells = useAtomValue(revealing_cells_atom);
   const boardRef = useRef<HTMLDivElement>(null);
 
   // Track which cells were "just solved" so we can fire the pulse animation once
@@ -68,6 +70,8 @@ export function CrossWordGrid({ game, onRequestKeyboard }: CrossWordGridProps) {
     }
     return map;
   }, [entries]);
+
+  const revealedSet = useMemo(() => new Set(revealingCells), [revealingCells]);
 
   const incorrectOnlyCells = useMemo(() => {
     const solvedCellKeys = new Set<string>();
@@ -121,6 +125,7 @@ export function CrossWordGrid({ game, onRequestKeyboard }: CrossWordGridProps) {
             const solved = game.isCellSolved(r, c);
             const incorrect = incorrectOnlyCells.has(cellKey(r, c));
             const justSolved = justSolvedCells.has(cellKey(r, c));
+            const revealed = revealedSet.has(cellKey(r, c));
 
             return (
               <div
@@ -141,6 +146,7 @@ export function CrossWordGrid({ game, onRequestKeyboard }: CrossWordGridProps) {
                   inActiveWord={inActiveWord}
                   solved={solved}
                   justSolved={justSolved}
+                  revealed={revealed}
                   incorrect={incorrect}
                   disabled={!game.started || game.completed}
                   onSelect={() => {

--- a/src/components/pages/cross_word/CrossWordGame/GameProgress.tsx
+++ b/src/components/pages/cross_word/CrossWordGame/GameProgress.tsx
@@ -4,21 +4,47 @@ import { useAtomValue } from 'jotai';
 import { motion } from 'framer-motion';
 import { Timer, Trophy } from 'lucide-react';
 import { formatElapsed } from '~/util/cross_word/game_model';
-import { completed_atom, progress_atom, seconds_atom, started_atom } from './game_state';
+import {
+  active_focus_atom,
+  completed_atom,
+  progress_atom,
+  seconds_atom,
+  solved_entry_ids_atom,
+  started_atom
+} from './game_state';
 import { ResetPuzzleButton } from './ResetPuzzleButton';
+import { RevealWordButton } from './RevealWordButton';
 import styles from './crossword-game.module.css';
 
 type GameProgressProps = {
   onReset?: () => void;
+  revealsLeft?: number;
+  revealingEntryId?: string | null;
+  onReveal?: (entryId: string) => void;
 };
 
-export function GameProgress({ onReset }: GameProgressProps) {
+export function GameProgress({
+  onReset,
+  revealsLeft = 0,
+  revealingEntryId = null,
+  onReveal
+}: GameProgressProps) {
   const started = useAtomValue(started_atom);
   const completed = useAtomValue(completed_atom);
   const seconds = useAtomValue(seconds_atom);
   const progress = useAtomValue(progress_atom);
+  const focus = useAtomValue(active_focus_atom);
+  const solvedIds = useAtomValue(solved_entry_ids_atom);
 
   if (!started) return null;
+
+  const focusedEntryId = focus?.entryId ?? null;
+  const canReveal = !!(
+    focusedEntryId &&
+    !solvedIds.includes(focusedEntryId) &&
+    !completed &&
+    onReveal
+  );
 
   return (
     <motion.div
@@ -61,7 +87,16 @@ export function GameProgress({ onReset }: GameProgressProps) {
         </span>
       </div>
 
-      {/* Trailing action — same status row, never overlaps the grid */}
+      {/* Trailing actions — same status row, never overlaps the grid */}
+      {!completed && onReveal ? (
+        <RevealWordButton
+          revealsLeft={revealsLeft}
+          busy={revealingEntryId !== null}
+          entryId={canReveal ? focusedEntryId : null}
+          onReveal={onReveal}
+          className="shrink-0"
+        />
+      ) : null}
       {!completed && onReset ? <ResetPuzzleButton onReset={onReset} className="shrink-0" /> : null}
     </motion.div>
   );

--- a/src/components/pages/cross_word/CrossWordGame/MorePuzzlesCarousel.tsx
+++ b/src/components/pages/cross_word/CrossWordGame/MorePuzzlesCarousel.tsx
@@ -26,11 +26,65 @@ import {
   completed_atom,
   pending_navigation_url_atom
 } from '~/components/pages/cross_word/CrossWordGame/game_state';
+import { PUZZLE_CARD_IMAGE_ASPECT_RATIO } from '~/components/pages/padavali/listed_puzzle_display';
 
 const carouselNavButtonClass =
   'static top-auto right-auto bottom-auto left-auto size-7 shrink-0 translate-x-0 translate-y-0 rounded-full border border-slate-300 bg-white text-slate-700 shadow-sm hover:bg-slate-50 disabled:opacity-35 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700';
 
 const carouselItemClass = 'basis-1/2 pl-3 sm:basis-1/3 lg:basis-1/4';
+
+/** Mirrors loaded carousel chrome + card anatomy (image 3:2 + title + description). */
+function MoreCrosswordPuzzlesCarouselSkeleton({
+  hideHeader,
+  compact,
+  className
+}: {
+  hideHeader: boolean;
+  compact: boolean;
+  className?: string;
+}) {
+  return (
+    <div className={cn(compact ? 'px-3 py-2 sm:py-3' : 'px-4 py-3 sm:py-4', className)}>
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-2.5 flex items-center gap-2 lg:justify-center">
+          <div className="min-w-0 flex-1 lg:hidden">
+            {!hideHeader ? (
+              <div className="h-5 w-28 animate-pulse rounded-md bg-slate-200 dark:bg-slate-700" />
+            ) : (
+              <div className="h-3.5 w-24 animate-pulse rounded-md bg-slate-200 dark:bg-slate-700" />
+            )}
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <div className="h-6 w-18 animate-pulse rounded-full bg-slate-200 dark:bg-slate-700" />
+            <div className="size-7 animate-pulse rounded-full bg-slate-200 dark:bg-slate-700" />
+            <div className="size-7 animate-pulse rounded-full bg-slate-200 dark:bg-slate-700" />
+          </div>
+        </div>
+
+        <div className="overflow-hidden">
+          <div className="-ml-3 flex">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className={cn('min-w-0 shrink-0 grow-0', carouselItemClass)}>
+                <div className="flex flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-800">
+                  <div
+                    className="w-full animate-pulse bg-slate-200 dark:bg-slate-700"
+                    style={{
+                      aspectRatio: `${PUZZLE_CARD_IMAGE_ASPECT_RATIO[0]} / ${PUZZLE_CARD_IMAGE_ASPECT_RATIO[1]}`
+                    }}
+                  />
+                  <div className={cn('flex flex-col gap-1.5', compact ? 'p-2' : 'p-3')}>
+                    <div className="h-4 w-[85%] animate-pulse rounded-md bg-slate-200 dark:bg-slate-700" />
+                    <div className="h-3 w-[60%] animate-pulse rounded-md bg-slate-200/80 dark:bg-slate-600" />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function useLeaveGameGuard() {
   const [started] = useAtom(started_atom);
@@ -110,21 +164,11 @@ export const MoreCrosswordPuzzlesCarousel = ({
 
   if (puzzles_q.isLoading) {
     return (
-      <div className={cn(compact ? 'px-3 py-3' : 'px-4 py-4', className)}>
-        <div className="mx-auto max-w-6xl">
-          {!hideHeader && (
-            <div className="mb-3 h-5 w-32 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
-          )}
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <div
-                key={i}
-                className="aspect-3/2 animate-pulse rounded-xl bg-slate-200 dark:bg-slate-700"
-              />
-            ))}
-          </div>
-        </div>
-      </div>
+      <MoreCrosswordPuzzlesCarouselSkeleton
+        hideHeader={hideHeader}
+        compact={compact}
+        className={className}
+      />
     );
   }
 

--- a/src/components/pages/cross_word/CrossWordGame/RevealWordButton.tsx
+++ b/src/components/pages/cross_word/CrossWordGame/RevealWordButton.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useState } from 'react';
+import { Eye } from 'lucide-react';
+import { Button } from '~/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '~/components/ui/alert-dialog';
+import { cn } from '~/lib/utils';
+import { MAX_WORD_REVEALS } from './game_state';
+
+type RevealWordButtonProps = {
+  revealsLeft: number;
+  /** True while a reveal animation is in flight. */
+  busy: boolean;
+  /** Focused, unsolved entry id — null when reveal isn't available. */
+  entryId: string | null;
+  onReveal: (entryId: string) => void;
+  className?: string;
+};
+
+/** Progress-row lifeline — reveals the currently selected crossword word. */
+export function RevealWordButton({
+  revealsLeft,
+  busy,
+  entryId,
+  onReveal,
+  className
+}: RevealWordButtonProps) {
+  const [open, setOpen] = useState(false);
+  /** Snapshot so a backdrop click can't clear focus before Confirm. */
+  const [pendingEntryId, setPendingEntryId] = useState<string | null>(null);
+  const spent = revealsLeft <= 0;
+  const canReveal = !!entryId;
+  const disabled = spent || busy || !canReveal;
+
+  const title = spent
+    ? 'No reveals left'
+    : busy
+      ? 'Revealing…'
+      : !canReveal
+        ? 'Select a word to reveal'
+        : `Reveal selected word (${revealsLeft} of ${MAX_WORD_REVEALS} left)`;
+
+  return (
+    <>
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        disabled={disabled}
+        onClick={() => {
+          if (!entryId) return;
+          setPendingEntryId(entryId);
+          setOpen(true);
+        }}
+        aria-label={title}
+        title={title}
+        className={cn(
+          'h-8 gap-1 rounded-full border px-2.5 font-semibold tabular-nums shadow-sm backdrop-blur-md',
+          'border-amber-500/30 bg-linear-to-r from-orange-50/90 to-amber-50/80 text-amber-800',
+          'hover:from-orange-100 hover:to-amber-100 hover:text-amber-900',
+          'dark:border-amber-400/35 dark:from-orange-950/70 dark:to-amber-950/60 dark:text-amber-200',
+          'dark:hover:from-orange-900/80 dark:hover:to-amber-900/70 dark:hover:text-amber-100',
+          'disabled:pointer-events-none disabled:opacity-40',
+          className
+        )}
+      >
+        <Eye className="size-3.5 shrink-0" />
+        <span className="text-[0.7rem] leading-none">
+          {spent ? '0' : revealsLeft}/{MAX_WORD_REVEALS}
+        </span>
+      </Button>
+
+      <AlertDialog
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) setPendingEntryId(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Reveal this word?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This uses 1 of your {MAX_WORD_REVEALS} reveals for this session. The selected word
+              will be filled in for you.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className={cn(
+                'bg-linear-to-r from-orange-600 to-amber-700 text-white',
+                'hover:from-orange-500 hover:to-amber-600',
+                'dark:from-orange-700 dark:to-amber-800 dark:hover:from-orange-600 dark:hover:to-amber-700'
+              )}
+              onClick={() => {
+                if (pendingEntryId) onReveal(pendingEntryId);
+                setPendingEntryId(null);
+                setOpen(false);
+              }}
+            >
+              Reveal
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/pages/cross_word/CrossWordGame/crossword-game.module.css
+++ b/src/components/pages/cross_word/CrossWordGame/crossword-game.module.css
@@ -176,6 +176,30 @@
   }
 }
 
+/* ── Reveal power-up flash — amber ring as each letter lands ── */
+.cellRevealed {
+  animation: revealedPulse 0.45s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+@keyframes revealedPulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 oklch(0.75 0.16 70 / 0.85);
+  }
+  40% {
+    transform: scale(1.12);
+    box-shadow: 0 0 0 7px oklch(0.75 0.16 70 / 0.45);
+  }
+  70% {
+    transform: scale(0.97);
+    box-shadow: 0 0 0 12px oklch(0.75 0.16 70 / 0.15);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 16px oklch(0.75 0.16 70 / 0);
+  }
+}
+
 /* ── Incorrect cell shake ── */
 .cellIncorrect {
   animation: shake 0.36s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
@@ -422,6 +446,7 @@
 
 @media (prefers-reduced-motion: reduce) {
   .cellJustSolved,
+  .cellRevealed,
   .cellIncorrect,
   .progressFill,
   .playCell:not(:disabled):hover {

--- a/src/components/pages/cross_word/CrossWordGame/game_state.ts
+++ b/src/components/pages/cross_word/CrossWordGame/game_state.ts
@@ -43,6 +43,16 @@ export const letter_inputs_atom = atom(0);
  */
 export const incorrect_entry_attempts_atom = atom(0);
 
+/** Max word reveals allowed per play session. */
+export const MAX_WORD_REVEALS = 3;
+/** How many reveal power-ups have been used this session. */
+export const reveals_used_atom = atom(0);
+/** Entry id currently animating a reveal; blocks all input while non-null. */
+export const revealing_entry_id_atom = atom<string | null>(null);
+/** Cell keys that just landed from a reveal (drives the amber flash). */
+export const revealing_cells_atom = atom<string[]>([]);
+export const reveals_left_atom = atom((get) => MAX_WORD_REVEALS - get(reveals_used_atom));
+
 export const progress_atom = atom((get) => {
   const entries = get(numbered_entries_atom);
   const solved = get(solved_entry_ids_atom);

--- a/src/components/pages/cross_word/CrossWordGame/useCrossWordGame.ts
+++ b/src/components/pages/cross_word/CrossWordGame/useCrossWordGame.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { type RefObject, useCallback, useEffect } from 'react';
+import { type RefObject, useCallback, useEffect, useRef } from 'react';
 import { useAtom, useAtomValue, useSetAtom, useStore } from 'jotai';
 import {
   active_focus_atom,
@@ -10,14 +10,20 @@ import {
   incorrect_entry_attempts_atom,
   incorrect_entry_ids_atom,
   letter_inputs_atom,
+  MAX_WORD_REVEALS,
   numbered_entries_atom,
   player_grid_atom,
   puzzle_atom,
+  revealing_cells_atom,
+  revealing_entry_id_atom,
+  reveals_left_atom,
+  reveals_used_atom,
   seconds_atom,
   solved_entry_ids_atom,
   started_atom
 } from './game_state';
 import {
+  cellKey,
   createEmptyPlayerGrid,
   findEntriesAtCell,
   getEntryCells,
@@ -32,6 +38,10 @@ import {
   type CrossWordGamePuzzle,
   type NumberedEntry
 } from '~/util/cross_word/game_model';
+
+const REVEAL_START_DELAY_MS = 200;
+const REVEAL_STEP_MS = 130;
+const REVEAL_FLASH_CLEAR_MS = 500;
 
 function pickPreferredEntry(
   covering: CrossWordEntry[],
@@ -84,6 +94,11 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
   const setCelebrationFired = useSetAtom(celebration_fired_atom);
   const setLetterInputs = useSetAtom(letter_inputs_atom);
   const setIncorrectAttempts = useSetAtom(incorrect_entry_attempts_atom);
+  const [revealsUsed, setRevealsUsed] = useAtom(reveals_used_atom);
+  const [revealingEntryId, setRevealingEntryId] = useAtom(revealing_entry_id_atom);
+  const setRevealingCells = useSetAtom(revealing_cells_atom);
+  const revealsLeft = useAtomValue(reveals_left_atom);
+  const revealTimersRef = useRef<number[]>([]);
 
   const clearTimer = useCallback(() => {
     if (timerRef.current) {
@@ -92,9 +107,19 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
     }
   }, [timerRef]);
 
+  const clearRevealTimers = useCallback(() => {
+    for (const id of revealTimersRef.current) {
+      window.clearTimeout(id);
+    }
+    revealTimersRef.current = [];
+  }, []);
+
   useEffect(() => {
-    return clearTimer;
-  }, [clearTimer]);
+    return () => {
+      clearTimer();
+      clearRevealTimers();
+    };
+  }, [clearTimer, clearRevealTimers]);
 
   const startTimer = useCallback(() => {
     clearTimer();
@@ -122,6 +147,7 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
   const focusCell = useCallback(
     (row: number, col: number, options?: { direction?: CrossWordDirection; toggle?: boolean }) => {
       if (!puzzle) return;
+      if (store.get(revealing_entry_id_atom)) return;
       const template = puzzle.grid[row]?.[col];
       if (template === null || template === undefined) return;
 
@@ -209,6 +235,7 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
 
   const startGame = useCallback(() => {
     if (!puzzle) return;
+    clearRevealTimers();
     setPlayerGrid(createEmptyPlayerGrid(puzzle.grid));
     setStarted(true);
     setCompleted(false);
@@ -218,6 +245,9 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
     setCelebrationFired(false);
     setLetterInputs(0);
     setIncorrectAttempts(0);
+    setRevealsUsed(0);
+    setRevealingEntryId(null);
+    setRevealingCells([]);
     setNonce((n) => n + 1);
 
     const first = entries[0];
@@ -240,6 +270,7 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
 
     startTimer();
   }, [
+    clearRevealTimers,
     entries,
     puzzle,
     setCelebrationFired,
@@ -250,6 +281,9 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
     setLetterInputs,
     setNonce,
     setPlayerGrid,
+    setRevealingCells,
+    setRevealingEntryId,
+    setRevealsUsed,
     setSeconds,
     setSolved,
     setStarted,
@@ -259,6 +293,7 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
   const resetGame = useCallback(() => {
     if (!puzzle) return;
     clearTimer();
+    clearRevealTimers();
     setPlayerGrid(createEmptyPlayerGrid(puzzle.grid));
     setStarted(false);
     setCompleted(false);
@@ -268,9 +303,13 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
     setCelebrationFired(false);
     setLetterInputs(0);
     setIncorrectAttempts(0);
+    setRevealsUsed(0);
+    setRevealingEntryId(null);
+    setRevealingCells([]);
     setFocus(null);
     setNonce((n) => n + 1);
   }, [
+    clearRevealTimers,
     clearTimer,
     puzzle,
     setCelebrationFired,
@@ -281,6 +320,9 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
     setLetterInputs,
     setNonce,
     setPlayerGrid,
+    setRevealingCells,
+    setRevealingEntryId,
+    setRevealsUsed,
     setSeconds,
     setSolved,
     setStarted
@@ -305,6 +347,7 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
     (letter: string) => {
       const currentFocus = store.get(active_focus_atom);
       if (!puzzle || !started || completed || !currentFocus) return;
+      if (store.get(revealing_entry_id_atom)) return;
       const normalized = letter.toUpperCase();
       if (!/^[A-Z]$/.test(normalized)) return;
 
@@ -395,6 +438,7 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
   const backspace = useCallback(() => {
     const currentFocus = store.get(active_focus_atom);
     if (!puzzle || !started || completed || !currentFocus) return;
+    if (store.get(revealing_entry_id_atom)) return;
     const template = puzzle.grid[currentFocus.row]?.[currentFocus.col];
     const currentGrid = store.get(player_grid_atom);
     const currentValue = currentGrid[currentFocus.row]?.[currentFocus.col] ?? '';
@@ -469,6 +513,7 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (!started || completed) return;
+      if (store.get(revealing_entry_id_atom)) return;
 
       if (event.key === 'Tab') {
         event.preventDefault();
@@ -532,6 +577,7 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
       puzzle,
       setFocus,
       started,
+      store,
       typeLetter
     ]
   );
@@ -559,8 +605,9 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
   );
 
   const clearFocus = useCallback(() => {
+    if (store.get(revealing_entry_id_atom)) return;
     setFocus(null);
-  }, [setFocus]);
+  }, [setFocus, store]);
 
   /**
    * True when the focused cell sits at an Across ∩ Down intersection,
@@ -575,8 +622,9 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
   /** Flip Across ↔ Down at the current intersection (same as re-tapping / Space). */
   const toggleDirection = useCallback(() => {
     if (!focus || !canToggleDirection) return;
+    if (store.get(revealing_entry_id_atom)) return;
     focusCell(focus.row, focus.col, { toggle: true });
-  }, [canToggleDirection, focus, focusCell]);
+  }, [canToggleDirection, focus, focusCell, store]);
 
   const getDisplayLetter = useCallback(
     (row: number, col: number) => {
@@ -587,6 +635,99 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
       return playerGrid[row]?.[col] ?? '';
     },
     [playerGrid, puzzle]
+  );
+
+  /**
+   * Reveal the selected word letter-by-letter (consumes one of MAX_WORD_REVEALS).
+   * Skips prefilled cells and cells that already hold the correct letter.
+   * Evaluation runs only after the last letter lands so crossing words don't flash red mid-animation.
+   */
+  const revealEntry = useCallback(
+    (entryId: string) => {
+      if (!puzzle || !started || completed) return;
+      if (store.get(revealing_entry_id_atom)) return;
+      if (store.get(reveals_used_atom) >= MAX_WORD_REVEALS) return;
+
+      const entry = entries.find((e) => e.id === entryId);
+      if (!entry) return;
+      if (store.get(solved_entry_ids_atom).includes(entryId)) return;
+
+      const currentGrid = store.get(player_grid_atom);
+      const cells = getEntryCells(entry);
+      const writes: { row: number; col: number; letter: string }[] = [];
+
+      for (let i = 0; i < cells.length; i++) {
+        const cell = cells[i]!;
+        const template = puzzle.grid[cell.row]?.[cell.col] ?? null;
+        if (isFixedCell(template)) continue;
+
+        const correct = entry.answer[i]!.toUpperCase();
+        const current = (currentGrid[cell.row]?.[cell.col] ?? '').toUpperCase();
+        if (current === correct) continue;
+
+        writes.push({ row: cell.row, col: cell.col, letter: correct });
+      }
+
+      if (writes.length === 0) return;
+
+      clearRevealTimers();
+      setRevealsUsed((n) => n + 1);
+      setRevealingEntryId(entryId);
+      setRevealingCells([]);
+
+      // Keep focus on this entry so the cursor walks along during the animation.
+      const first = writes[0]!;
+      setFocus({
+        row: first.row,
+        col: first.col,
+        direction: entry.direction,
+        entryId: entry.id
+      });
+
+      writes.forEach((write, index) => {
+        const isLast = index === writes.length - 1;
+        const timerId = window.setTimeout(
+          () => {
+            const prevGrid = store.get(player_grid_atom);
+            const nextGrid = prevGrid.map((row) => [...row]);
+            nextGrid[write.row]![write.col] = write.letter;
+            setPlayerGrid(nextGrid);
+            setRevealingCells((prev) => [...prev, cellKey(write.row, write.col)]);
+            setFocus({
+              row: write.row,
+              col: write.col,
+              direction: entry.direction,
+              entryId: entry.id
+            });
+
+            if (isLast) {
+              applyEvaluation(nextGrid);
+              setRevealingEntryId(null);
+              const clearId = window.setTimeout(() => {
+                setRevealingCells([]);
+              }, REVEAL_FLASH_CLEAR_MS);
+              revealTimersRef.current.push(clearId);
+            }
+          },
+          REVEAL_START_DELAY_MS + index * REVEAL_STEP_MS
+        );
+        revealTimersRef.current.push(timerId);
+      });
+    },
+    [
+      applyEvaluation,
+      clearRevealTimers,
+      completed,
+      entries,
+      puzzle,
+      setFocus,
+      setPlayerGrid,
+      setRevealingCells,
+      setRevealingEntryId,
+      setRevealsUsed,
+      started,
+      store
+    ]
   );
 
   return {
@@ -608,6 +749,10 @@ export function useCrossWordGame(timerRef: RefObject<ReturnType<typeof setInterv
     isCellSolved,
     getDisplayLetter,
     clearTimer,
-    clearFocus
+    clearFocus,
+    revealEntry,
+    revealingEntryId,
+    revealsLeft,
+    revealsUsed
   };
 }

--- a/src/components/pages/padavali/WordGame/MorePuzzlesCarousel.tsx
+++ b/src/components/pages/padavali/WordGame/MorePuzzlesCarousel.tsx
@@ -42,6 +42,59 @@ const carouselNavButtonClass =
 
 const carouselItemClass = 'basis-1/2 pl-3 sm:basis-1/3 lg:basis-1/4';
 
+/** Mirrors loaded carousel chrome + card anatomy (image 3:2 + title + description). */
+function MorePuzzlesCarouselSkeleton({
+  hideHeader,
+  compact,
+  className
+}: {
+  hideHeader: boolean;
+  compact: boolean;
+  className?: string;
+}) {
+  return (
+    <div className={cn(compact ? 'px-3 py-2 sm:py-3' : 'px-4 py-3 sm:py-4', className)}>
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-2.5 flex items-center gap-2 lg:justify-center">
+          <div className="min-w-0 flex-1 lg:hidden">
+            {!hideHeader ? (
+              <div className="h-5 w-28 animate-pulse rounded-md bg-slate-200 dark:bg-slate-700" />
+            ) : (
+              <div className="h-3.5 w-24 animate-pulse rounded-md bg-slate-200 dark:bg-slate-700" />
+            )}
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <div className="h-6 w-18 animate-pulse rounded-full bg-slate-200 dark:bg-slate-700" />
+            <div className="size-7 animate-pulse rounded-full bg-slate-200 dark:bg-slate-700" />
+            <div className="size-7 animate-pulse rounded-full bg-slate-200 dark:bg-slate-700" />
+          </div>
+        </div>
+
+        <div className="overflow-hidden">
+          <div className="-ml-3 flex">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className={cn('min-w-0 shrink-0 grow-0', carouselItemClass)}>
+                <div className="flex flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-800">
+                  <div
+                    className="w-full animate-pulse bg-slate-200 dark:bg-slate-700"
+                    style={{
+                      aspectRatio: `${PUZZLE_CARD_IMAGE_ASPECT_RATIO[0]} / ${PUZZLE_CARD_IMAGE_ASPECT_RATIO[1]}`
+                    }}
+                  />
+                  <div className={cn('flex flex-col gap-1.5', compact ? 'p-2' : 'p-3')}>
+                    <div className="h-4 w-[85%] animate-pulse rounded-md bg-slate-200 dark:bg-slate-700" />
+                    <div className="h-3 w-[60%] animate-pulse rounded-md bg-slate-200/80 dark:bg-slate-600" />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 const ExploreMoreCarouselCard = () => {
   const [w, h] = PUZZLE_CARD_IMAGE_ASPECT_RATIO;
   const [started] = useAtom(started_atom);
@@ -145,21 +198,11 @@ export const MorePuzzlesCarousel = ({
 
   if (puzzles_q.isLoading) {
     return (
-      <div className={cn(compact ? 'px-3 py-3' : 'px-4 py-4', className)}>
-        <div className="mx-auto max-w-6xl">
-          {!hideHeader && (
-            <div className="mb-3 h-5 w-32 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
-          )}
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <div
-                key={i}
-                className="aspect-3/2 animate-pulse rounded-xl bg-slate-200 dark:bg-slate-700"
-              />
-            ))}
-          </div>
-        </div>
-      </div>
+      <MorePuzzlesCarouselSkeleton
+        hideHeader={hideHeader}
+        compact={compact}
+        className={className}
+      />
     );
   }
 


### PR DESCRIPTION
- **feat: Implement word reveal feature with animations and state management**
- **refactor: Simplify CluePanel and enhance GameProgress with reveal functionality**
- **feat: Add skeleton loading component for MorePuzzlesCarousel in CrossWordGame and WordGame**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a word-reveal option for crossword puzzles, with up to three reveals per session.
  - Added confirmation prompts, reveal progress indicators, and animated letter-by-letter reveals.
  - Crossword input is temporarily paused while a reveal is in progress.

- **Bug Fixes**
  - Clicking alert dialogs or their overlays no longer clears the crossword’s active selection.

- **UI Improvements**
  - Added reveal animations for newly displayed crossword cells.
  - Improved loading placeholders for crossword and word-game puzzle carousels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->