### PR TITLE
feat: Add 'added' field in word list, prepeare for more complex edit flows

### DIFF
--- a/src/api/routers/crossword/crossword_stats.ts
+++ b/src/api/routers/crossword/crossword_stats.ts
@@ -15,6 +15,7 @@ import {
 } from '~/db/crossword_shared';
 import { BadRequestError } from '~/effect/errors';
 import { runTrpcEffect } from '~/effect/run';
+import { crosswordActiveWords } from '~/util/puzzle/word_list';
 
 const verifyTurnstile = Effect.fn('crosswordStats.verifyTurnstile')(function* (token: string) {
   const is_valid = yield* verify_cloudflare_turnstile_token(token);
@@ -202,7 +203,10 @@ const get_stats_data_route = protectedAdminProcedure
           )
         });
 
-        const total_words = puzzles.reduce((sum, puzzle) => sum + puzzle.word_list.length, 0);
+        const total_words = puzzles.reduce(
+          (sum, puzzle) => sum + crosswordActiveWords(puzzle.word_list).length,
+          0
+        );
 
         return { sessions, stats, total_words };
       })

--- a/src/api/routers/crossword/puzzle_routes.ts
+++ b/src/api/routers/crossword/puzzle_routes.ts
@@ -39,6 +39,7 @@ import { crossword_schedules_router } from './crossword_schedules';
 import { more_hints_inputs_equal } from '~/util/ai/more_hints';
 import { BadRequestError, NotFoundError } from '~/effect/errors';
 import { runTrpcEffect } from '~/effect/run';
+import { crosswordActiveWordList } from '~/util/puzzle/word_list';
 
 type AttachmentInput = z.infer<typeof CrosswordUpdateInputSchema>['puzzle_data']['attachments'];
 
@@ -182,7 +183,16 @@ const get_listed_puzzles_route = publicProcedure.query(() =>
         .from(crossword_puzzles)
         .where(eq(crossword_puzzles.listed, true))
         .orderBy(desc(crossword_puzzles.last_listed_at), desc(crossword_puzzles.created_at))
-    ).pipe(Effect.map((rows) => rows.map((row) => CrossordPuzzleSchemaZod.parse(row))))
+    ).pipe(
+      Effect.map((rows) =>
+        rows.map((row) =>
+          CrossordPuzzleSchemaZod.parse({
+            ...row,
+            word_list: crosswordActiveWordList(row.word_list)
+          })
+        )
+      )
+    )
   )
 );
 

--- a/src/api/routers/padavali_stats.ts
+++ b/src/api/routers/padavali_stats.ts
@@ -13,6 +13,7 @@ import { script_list_enum } from '~/state/script_list';
 import { and, count, desc, eq, gte, inArray, lte } from 'drizzle-orm';
 import { BadRequestError } from '~/effect/errors';
 import { runTrpcEffect } from '~/effect/run';
+import { padavaliActiveWords } from '~/util/puzzle/word_list';
 
 const verifyTurnstile = Effect.fn('padavaliStats.verifyTurnstile')(function* (token: string) {
   const is_valid = yield* verify_cloudflare_turnstile_token(token);
@@ -235,7 +236,10 @@ const get_stats_data_route = protectedAdminProcedure
           )
         });
 
-        const total_words = puzzles.reduce((sum, puzzle) => sum + puzzle.word_list.length, 0);
+        const total_words = puzzles.reduce(
+          (sum, puzzle) => sum + padavaliActiveWords(puzzle.word_list).length,
+          0
+        );
 
         return { sessions, stats, correct_attempts: total_words };
       })

--- a/src/api/routers/puzzle.ts
+++ b/src/api/routers/puzzle.ts
@@ -33,6 +33,7 @@ import { escapeIlikeToken, tokenizeSearchQuery } from '~/util/puzzle/search';
 import { BadRequestError, ConflictError, NotFoundError } from '~/effect/errors';
 import { AppConfig } from '~/effect/config';
 import { runTrpcEffect } from '~/effect/run';
+import { padavaliActiveWordsEqual } from '~/util/puzzle/word_list';
 
 const settle = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(Effect.catch(() => Effect.void));
@@ -281,9 +282,6 @@ const check_slug_availability_route = protectedAdminProcedure
     runTrpcEffect(resolve_slug_availability(slug, { exclude_puzzle_id }))
   );
 
-const word_lists_equal = (a: string[], b: string[]) =>
-  a.length === b.length && a.every((word, i) => word === b[i]);
-
 const update_puzzle_route = protectedAdminProcedure
   .input(puzzle_update_input_schema)
   .mutation(({ input: { puzzle_id, puzzle_data, puzzle_slug, image_id } }) =>
@@ -314,7 +312,7 @@ const update_puzzle_route = protectedAdminProcedure
         const meanings_input_changed =
           existing.title !== puzzle_data.title ||
           existing.description !== puzzle_data.description ||
-          !word_lists_equal(existing.word_list, puzzle_data.word_list);
+          !padavaliActiveWordsEqual(existing.word_list, puzzle_data.word_list);
 
         const { updated_count, newly_added_index_ids } = yield* dbTransaction(
           'padavali.update_puzzle',

--- a/src/app/LandingPage.tsx
+++ b/src/app/LandingPage.tsx
@@ -246,9 +246,7 @@ export function PadavaliMiniPreview() {
 
     const sync = () => {
       setTrailPoints({
-        found: Object.fromEntries(
-          foundWords.map((word) => [word.text, buildPoints(word.path)])
-        ),
+        found: Object.fromEntries(foundWords.map((word) => [word.text, buildPoints(word.path)])),
         demo: buildPoints(demoPath)
       });
     };

--- a/src/app/padajala/(auth)/list/AddCrosswordDialog.tsx
+++ b/src/app/padajala/(auth)/list/AddCrosswordDialog.tsx
@@ -79,8 +79,7 @@ const AddCrosswordDialog = () => {
     isValidSlugFn: isValidCrosswordSlug
   });
 
-  const effectiveOverrideRedirectSlug =
-    overrideRedirectSlug && overrideForSlug === normalizedSlug;
+  const effectiveOverrideRedirectSlug = overrideRedirectSlug && overrideForSlug === normalizedSlug;
 
   const add_mut = client_q.crossword.add_puzzle.useMutation({
     onSuccess(data) {

--- a/src/app/padavali/(auth)/list/AddPuzzleDialog.tsx
+++ b/src/app/padavali/(auth)/list/AddPuzzleDialog.tsx
@@ -82,8 +82,7 @@ const AddPuzzleDialog = () => {
     enabled: open
   });
 
-  const effectiveOverrideRedirectSlug =
-    overrideRedirectSlug && overrideForSlug === normalizedSlug;
+  const effectiveOverrideRedirectSlug = overrideRedirectSlug && overrideForSlug === normalizedSlug;
 
   const add_puzzle_mut = client_q.puzzle.add_puzzle.useMutation({
     onSuccess(data) {

--- a/src/components/Turnstile.tsx
+++ b/src/components/Turnstile.tsx
@@ -8,7 +8,11 @@ type Props = {
 const subscribe = () => () => {};
 
 export default function TurnstileWidget({ setToken }: Props) {
-  const mounted = useSyncExternalStore(subscribe, () => true, () => false);
+  const mounted = useSyncExternalStore(
+    subscribe,
+    () => true,
+    () => false
+  );
   const SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY!;
   const PROD = process.env.NODE_ENV === 'production';
 

--- a/src/components/pages/cross_word/CrosswordPreviewCard.tsx
+++ b/src/components/pages/cross_word/CrosswordPreviewCard.tsx
@@ -39,13 +39,7 @@ export function CrosswordPreviewCard({ puzzle, compact = false, onNavigate }: Pr
           style={{ aspectRatio: `${w} / ${h}` }}
         >
           {imageUrl ? (
-            <Image
-              src={imageUrl}
-              alt=""
-              fill
-              unoptimized
-              className="object-cover object-center"
-            />
+            <Image src={imageUrl} alt="" fill unoptimized className="object-cover object-center" />
           ) : (
             <div className="flex size-full items-center justify-center bg-linear-to-br from-slate-600 via-slate-700 to-slate-800 dark:from-slate-700 dark:via-slate-800 dark:to-slate-900">
               <IoExtensionPuzzleSharp

--- a/src/components/pages/cross_word/ViewEditCrossword.tsx
+++ b/src/components/pages/cross_word/ViewEditCrossword.tsx
@@ -97,6 +97,7 @@ import {
   useEditorHistoryActions,
   useHistoryTextField
 } from '~/hooks/useEditorHistory';
+import { Checkbox } from '~/components/ui/checkbox';
 
 type EditableWord = {
   id: string;
@@ -104,6 +105,7 @@ type EditableWord = {
   description: string;
   location: [number, number];
   direction: CrossWordPuzzleWord['direction'];
+  added: boolean;
 };
 
 type EditableAttachment = Omit<z.infer<typeof attachment_schema>, 'id'> & {
@@ -160,16 +162,18 @@ function toEditableWords(words: CrossWordPuzzleWord[]): EditableWord[] {
     word: w.word,
     description: w.description,
     location: w.location,
-    direction: w.direction
+    direction: w.direction,
+    added: w.added
   }));
 }
 
 function editableWordsComparable(words: EditableWord[]) {
-  return words.map(({ word, description, location, direction }) => ({
+  return words.map(({ word, description, location, direction, added }) => ({
     word,
     description,
     location,
-    direction
+    direction,
+    added
   }));
 }
 
@@ -244,7 +248,10 @@ const CrosswordPuzzleImageSection = ({ puzzleId }: { puzzleId: number }) => {
       game="crossword"
       title={title}
       description={description}
-      words={wordList.map((w) => w.word).filter((w) => w.trim().length > 0)}
+      words={wordList
+        .filter((w) => w.added)
+        .map((w) => w.word)
+        .filter((w) => w.trim().length > 0)}
       imageId={image_id}
       imageInfo={image_info}
       onImageIdChange={setImageId}
@@ -657,7 +664,8 @@ const WordListEditor = () => {
         word: '',
         description: '',
         location: [0, 0],
-        direction: 'horizontal'
+        direction: 'horizontal',
+        added: true
       }
     ]);
 
@@ -688,6 +696,13 @@ const WordListEditor = () => {
                 exit={{ opacity: 0, height: 0 }}
                 className="flex flex-wrap items-start gap-2 overflow-hidden sm:flex-nowrap"
               >
+                <Checkbox
+                  checked={item.added}
+                  onCheckedChange={(checked) => updateWord(idx, { added: checked === true })}
+                  aria-label={item.added ? 'Disable word' : 'Enable word'}
+                  title={item.added ? 'Included in puzzle' : 'Excluded from puzzle'}
+                  className="mt-2.5"
+                />
                 <Input
                   value={item.word}
                   onChange={(e) =>
@@ -698,7 +713,7 @@ const WordListEditor = () => {
                   onFocus={historyField.onFocus}
                   onBlur={historyField.onBlur}
                   placeholder="WORD"
-                  className="w-36 font-mono uppercase sm:w-44"
+                  className={cn('w-36 font-mono uppercase sm:w-44', !item.added && 'opacity-60')}
                 />
                 <Input
                   value={item.description}
@@ -706,7 +721,7 @@ const WordListEditor = () => {
                   onFocus={historyField.onFocus}
                   onBlur={historyField.onBlur}
                   placeholder="Clue / description"
-                  className="min-w-0 flex-1"
+                  className={cn('min-w-0 flex-1', !item.added && 'opacity-60')}
                 />
                 <span
                   className="inline-flex h-9 min-w-14 shrink-0 items-center justify-center rounded-md border border-border bg-muted/40 px-2 font-mono text-xs text-muted-foreground"
@@ -1207,7 +1222,7 @@ const SaveControls = ({ puzzle }: { puzzle: ViewEditCrosswordProps['puzzle'] }) 
     }
 
     const missingClue = wordList.find(
-      (w) => w.word.trim().length > 0 && w.description.trim().length === 0
+      (w) => w.added && w.word.trim().length > 0 && w.description.trim().length === 0
     );
     if (missingClue) {
       toast.error(`Add a clue for "${missingClue.word.trim().toUpperCase()}"`);
@@ -1230,7 +1245,8 @@ const SaveControls = ({ puzzle }: { puzzle: ViewEditCrosswordProps['puzzle'] }) 
             word: w.word,
             location: w.location,
             direction: w.direction,
-            description: w.description.trim()
+            description: w.description.trim(),
+            added: w.added
           })),
         attachments
       }

--- a/src/components/pages/padavali/PuzzlePreviewCard.tsx
+++ b/src/components/pages/padavali/PuzzlePreviewCard.tsx
@@ -58,13 +58,7 @@ export const PuzzlePreviewCard = ({ puzzle, compact = false }: Props) => {
           style={{ aspectRatio: `${w} / ${h}` }}
         >
           {imageUrl ? (
-            <Image
-              src={imageUrl}
-              alt=""
-              fill
-              unoptimized
-              className="object-cover object-center"
-            />
+            <Image src={imageUrl} alt="" fill unoptimized className="object-cover object-center" />
           ) : (
             <div className="flex size-full items-center justify-center bg-linear-to-br from-slate-600 via-slate-700 to-slate-800 dark:from-slate-700 dark:via-slate-800 dark:to-slate-900">
               <IoExtensionPuzzleSharp

--- a/src/components/pages/padavali/ViewEditPuzzle.tsx
+++ b/src/components/pages/padavali/ViewEditPuzzle.tsx
@@ -709,8 +709,8 @@ const TraversalAnalysis = ({
                     ) : warning.type === 'duplicate' ? (
                       <div className="flex items-center justify-center gap-2">
                         <span>
-                          &quot;<span className="font-semibold">{warning.word}</span>&quot;
-                          appears multiple times ({warning.traversalCount}) in the word list.
+                          &quot;<span className="font-semibold">{warning.word}</span>&quot; appears
+                          multiple times ({warning.traversalCount}) in the word list.
                         </span>
                         <Popover>
                           <PopoverTrigger

--- a/src/components/pages/padavali/ViewEditPuzzle.tsx
+++ b/src/components/pages/padavali/ViewEditPuzzle.tsx
@@ -63,10 +63,11 @@ import { useHydrateAtoms } from 'jotai/utils';
 import Icon from '~/tools/Icon';
 import { LanguageIcon } from '~/components/icons';
 import {
-  puzzle_schema as _puzzle_schema,
+  puzzle_editor_schema as _puzzle_schema,
   attachment_schema,
   ATTACHMENT_TYPE_NAMES,
-  puzzle_update_input_schema
+  puzzle_update_input_schema,
+  type PadavaliWordCandidate
 } from '~/db/db_shared_vals';
 import { SlugField } from '~/components/pages/padavali/EditSlugDialog';
 import {
@@ -89,6 +90,8 @@ import {
   useEditorHistoryActions,
   useHistoryTextField
 } from '~/hooks/useEditorHistory';
+import { Checkbox } from '~/components/ui/checkbox';
+import { padavaliActiveWords } from '~/util/puzzle/word_list';
 
 const ATTACHMENT_TYPE_ITEMS = [
   { label: 'Select attachment type', value: null },
@@ -124,7 +127,7 @@ export type Puzzle = z.infer<typeof puzzleSchema>;
 const BASE_SCRIPT = 'Devanagari';
 
 const title_atom = atom<string>('');
-const word_list_atom = atom<string[]>([]);
+const word_list_atom = atom<PadavaliWordCandidate[]>([]);
 const grid_data_atom = atom<string[][]>([]);
 const listed_atom = atom<boolean>(false);
 const description_atom = atom<string>('');
@@ -159,7 +162,7 @@ const ViewEditPuzzle = ({ word_puzzle: initialWordPuzzle }: ViewEditProps) => {
 
   useHydrateAtoms([
     [title_atom, word_puzzle.title],
-    [word_list_atom, [...word_puzzle.word_list]],
+    [word_list_atom, word_puzzle.word_list.map((entry) => ({ ...entry }))],
     [grid_data_atom, word_puzzle.grid_data.map((row) => [...row])],
     [listed_atom, word_puzzle.listed],
     [description_atom, word_puzzle.description],
@@ -480,10 +483,10 @@ const LipiLekhikaSwitch = () => {
 
 const getTraversalsInfo = (
   gridData: string[][],
-  wordList: string[],
+  wordList: PadavaliWordCandidate[],
   gridDimensions: [number, number]
 ) => {
-  const validWords = wordList.filter((word) => word.trim() !== '');
+  const validWords = padavaliActiveWords(wordList).filter((word) => word.trim() !== '');
   const traversalsMap = findAllTraversals(gridData, gridDimensions, validWords);
   return {
     validWords,
@@ -906,10 +909,13 @@ const WordList = () => {
   const [lipi_lekhika_active] = useAtom(lipi_lekhika_active_atom);
   const historyField = useHistoryTextField();
 
-  const addWord = () => setWordList((prev) => [...prev, '']);
+  const addWord = () => setWordList((prev) => [...prev, { word: '', added: true }]);
   const removeWord = (index: number) => setWordList((prev) => prev.filter((_, i) => i !== index));
   const updateWord = (index: number, value: string) => {
-    setWordList((prev) => prev.map((w, i) => (i === index ? value : w)));
+    setWordList((prev) => prev.map((w, i) => (i === index ? { ...w, word: value } : w)));
+  };
+  const toggleAdded = (index: number, added: boolean) => {
+    setWordList((prev) => prev.map((w, i) => (i === index ? { ...w, added } : w)));
   };
 
   const ctx = createTypingContext(BASE_SCRIPT);
@@ -919,7 +925,7 @@ const WordList = () => {
       <Label className="mb-2 block text-lg font-semibold">Word List</Label>
       <div className="grid max-w-7xl grid-cols-2 gap-2 space-y-2 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6">
         <AnimatePresence mode="popLayout">
-          {wordList.map((word, idx) => (
+          {wordList.map((entry, idx) => (
             <motion.div
               key={idx}
               initial={{ opacity: 0, height: 0, x: -20 }}
@@ -930,11 +936,17 @@ const WordList = () => {
               }}
               className="flex items-center space-x-2 overflow-hidden"
             >
+              <Checkbox
+                checked={entry.added}
+                onCheckedChange={(checked) => toggleAdded(idx, checked === true)}
+                aria-label={entry.added ? 'Disable word' : 'Enable word'}
+                title={entry.added ? 'Included in puzzle' : 'Excluded from puzzle'}
+              />
               <motion.div className="flex-1">
                 <Input
                   type="text"
-                  className="px- py-1 text-base"
-                  value={word}
+                  className={cn('px- py-1 text-base', !entry.added && 'opacity-60')}
+                  value={entry.word}
                   onChange={(e) => updateWord(idx, e.currentTarget.value)}
                   onBeforeInput={(e) =>
                     handleTypingBeforeInputEvent(
@@ -1343,7 +1355,7 @@ const PuzzleImageSection = ({ word_puzzle }: { word_puzzle: Puzzle }) => {
       game="padavali"
       title={title}
       description={description}
-      words={wordList}
+      words={padavaliActiveWords(wordList).filter((word) => word.trim().length > 0)}
       imageId={image_id}
       imageInfo={image_info}
       onImageIdChange={setImageId}

--- a/src/components/pages/padavali/WordGame/GameMetricsCollector.tsx
+++ b/src/components/pages/padavali/WordGame/GameMetricsCollector.tsx
@@ -105,7 +105,16 @@ const GameMetricsCollector = ({
         });
       });
     }
-  }, [started, turnstileToken, completed, practiceMode, puzzle_id, location, script, update_games_started_mut]);
+  }, [
+    started,
+    turnstileToken,
+    completed,
+    practiceMode,
+    puzzle_id,
+    location,
+    script,
+    update_games_started_mut
+  ]);
 
   const sessionId = update_games_started_mut.data?.session_id;
 

--- a/src/components/pages/padavali/WordGame/HintDialog.tsx
+++ b/src/components/pages/padavali/WordGame/HintDialog.tsx
@@ -161,7 +161,7 @@ export function HintDialog({ puzzle_id, puzzle_slug, timerRef }: Props) {
             ) : (
               <>
                 <p className="rounded-lg bg-amber-50/80 px-3 py-2 text-center text-xs leading-relaxed text-amber-900 dark:bg-amber-950/30 dark:text-amber-100">
-              Explore Word Meanings — Continue when you&apos;re ready.
+                  Explore Word Meanings — Continue when you&apos;re ready.
                 </p>
                 <WordMeaningsPanel
                   meanings={meanings}

--- a/src/components/pages/puzzle/PuzzleCardImageSection.tsx
+++ b/src/components/pages/puzzle/PuzzleCardImageSection.tsx
@@ -797,7 +797,7 @@ const CreateNewImageTab = ({
             <div className="space-y-1">
               <span className="text-xs text-muted-foreground">Image Prompt</span>
               <Textarea
-                className="min-h-[100px] w-full resize-y text-sm"
+                className="min-h-25 w-full resize-y text-sm"
                 value={custom_prompt}
                 onChange={(e) => setCustomPrompt(e.currentTarget.value)}
                 placeholder="Edit the image prompt…"

--- a/src/db/db_shared_vals.ts
+++ b/src/db/db_shared_vals.ts
@@ -1,7 +1,13 @@
 import { z } from 'zod';
 import { crossword_slug_schema, slug_schema } from '~/util/puzzle/slug';
+import { padavali_word_candidate_list_schema } from '~/util/puzzle/word_list';
 
 export { crossword_slug_schema, slug_schema };
+export {
+  padavali_word_candidate_schema,
+  padavali_word_candidate_list_schema,
+  type PadavaliWordCandidate
+} from '~/util/puzzle/word_list';
 
 export const ATTACHMENT_TYPE_LIST = [
   'link',
@@ -37,6 +43,7 @@ export const image_schema = z.object({
   height: z.number().int()
 });
 
+/** Public/cache Padavali puzzle — `word_list` is only enabled words as strings */
 export const puzzle_schema = z.object({
   id: z.number().int(),
   slug: z.string(),
@@ -52,30 +59,28 @@ export const puzzle_schema = z.object({
   image: image_schema.nullable()
 });
 
+/** Editor/DB Padavali puzzle — full candidate list with `added` flags */
+export const puzzle_editor_schema = puzzle_schema.extend({
+  word_list: padavali_word_candidate_list_schema
+});
+
 export const puzzle_update_input_schema = z.object({
   puzzle_id: z.number().int(),
   puzzle_slug: slug_schema,
   image_id: z.number().int().nullable(),
-  puzzle_data: puzzle_schema
-    .pick({
-      title: true,
-      listed: true,
-      word_list: true,
-      grid_data: true
-    })
-    .extend({
-      description: z.string().trim().min(1, 'Description is required')
-    })
-    .and(
-      z.object({
-        attachments: attachment_schema
-          .omit({ id: true })
-          .extend({
-            id: z.number().int().nullable()
-          })
-          .array()
+  puzzle_data: z.object({
+    title: z.string(),
+    listed: z.boolean(),
+    word_list: padavali_word_candidate_list_schema,
+    grid_data: z.string().array().array(),
+    description: z.string().trim().min(1, 'Description is required'),
+    attachments: attachment_schema
+      .omit({ id: true })
+      .extend({
+        id: z.number().int().nullable()
       })
-    )
+      .array()
+  })
 });
 
 export const puzzle_add_input_schema = z.object({

--- a/src/db/migrations/0019_spooky_unus.sql
+++ b/src/db/migrations/0019_spooky_unus.sql
@@ -1,6 +1,4 @@
 ALTER TABLE "padavali_puzzles" ALTER COLUMN "description" SET DEFAULT '';--> statement-breakpoint
 ALTER TABLE "padavali_puzzles" ALTER COLUMN "description" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "crossword_puzzles" ALTER COLUMN "description" SET DEFAULT '';--> statement-breakpoint
-ALTER TABLE "crossword_puzzles" ALTER COLUMN "description" SET NOT NULL;--> statement-breakpoint
-ALTER TABLE "padavali_puzzles" ADD COLUMN "word_candidates" jsonb;--> statement-breakpoint
-ALTER TABLE "crossword_puzzles" ADD COLUMN "word_candidates" jsonb;
+ALTER TABLE "crossword_puzzles" ALTER COLUMN "description" SET NOT NULL;

--- a/src/db/migrations/0019_uneven_marvel_boy.sql
+++ b/src/db/migrations/0019_uneven_marvel_boy.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "padavali_puzzles" ALTER COLUMN "description" SET DEFAULT '';--> statement-breakpoint
+ALTER TABLE "padavali_puzzles" ALTER COLUMN "description" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "crossword_puzzles" ALTER COLUMN "description" SET DEFAULT '';--> statement-breakpoint
+ALTER TABLE "crossword_puzzles" ALTER COLUMN "description" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "padavali_puzzles" ADD COLUMN "word_candidates" jsonb;--> statement-breakpoint
+ALTER TABLE "crossword_puzzles" ADD COLUMN "word_candidates" jsonb;

--- a/src/db/migrations/meta/0019_snapshot.json
+++ b/src/db/migrations/meta/0019_snapshot.json
@@ -1,0 +1,1589 @@
+{
+  "id": "41e550c1-38f7-4fd5-a107-134a531f8323",
+  "prevId": "2389eb0d-5b50-44c6-9928-6840590fb1f9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_batch_responses": {
+      "name": "ai_batch_responses",
+      "schema": "",
+      "columns": {
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_id": {
+          "name": "custom_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_approved": {
+          "name": "auto_approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_batch_responses_batch_id_ai_batches_batch_id_fk": {
+          "name": "ai_batch_responses_batch_id_ai_batches_batch_id_fk",
+          "tableFrom": "ai_batch_responses",
+          "tableTo": "ai_batches",
+          "columnsFrom": [
+            "batch_id"
+          ],
+          "columnsTo": [
+            "batch_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ai_batch_responses_batch_id_custom_id_pk": {
+          "name": "ai_batch_responses_batch_id_custom_id_pk",
+          "columns": [
+            "batch_id",
+            "custom_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_batches": {
+      "name": "ai_batches",
+      "schema": "",
+      "columns": {
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_resolved": {
+          "name": "output_resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "input_file_id": {
+          "name": "input_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_file_id": {
+          "name": "output_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.image_assets": {
+      "name": "image_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.padavali_attachments": {
+      "name": "padavali_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "puzzle_id": {
+          "name": "puzzle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "attachment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "padavali_attachments_puzzle_id_idx": {
+          "name": "padavali_attachments_puzzle_id_idx",
+          "columns": [
+            {
+              "expression": "puzzle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "padavali_attachments_puzzle_id_padavali_puzzles_id_fk": {
+          "name": "padavali_attachments_puzzle_id_padavali_puzzles_id_fk",
+          "tableFrom": "padavali_attachments",
+          "tableTo": "padavali_puzzles",
+          "columnsFrom": [
+            "puzzle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.padavali_gameplay_stats": {
+      "name": "padavali_gameplay_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "puzzle_id": {
+          "name": "puzzle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_taken": {
+          "name": "time_taken",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy": {
+          "name": "accuracy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct_attempts": {
+          "name": "correct_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_attempts": {
+          "name": "total_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "padavali_gameplay_stats_puzzle_id_created_at_idx": {
+          "name": "padavali_gameplay_stats_puzzle_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "puzzle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "padavali_gameplay_stats_session_id_idx": {
+          "name": "padavali_gameplay_stats_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "padavali_gameplay_stats_puzzle_id_padavali_puzzles_id_fk": {
+          "name": "padavali_gameplay_stats_puzzle_id_padavali_puzzles_id_fk",
+          "tableFrom": "padavali_gameplay_stats",
+          "tableTo": "padavali_puzzles",
+          "columnsFrom": [
+            "puzzle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "padavali_gameplay_stats_session_id_padavali_sessions_id_fk": {
+          "name": "padavali_gameplay_stats_session_id_padavali_sessions_id_fk",
+          "tableFrom": "padavali_gameplay_stats",
+          "tableTo": "padavali_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.padavali_puzzles": {
+      "name": "padavali_puzzles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_candidates": {
+          "name": "word_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_list": {
+          "name": "word_list",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grid_data": {
+          "name": "grid_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grid_dimensions": {
+          "name": "grid_dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listed": {
+          "name": "listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_listed_at": {
+          "name": "last_listed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "padavali_puzzles_slug_idx": {
+          "name": "padavali_puzzles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "padavali_puzzles_listed_created_at_idx": {
+          "name": "padavali_puzzles_listed_created_at_idx",
+          "columns": [
+            {
+              "expression": "listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "padavali_puzzles_listed_updated_at_idx": {
+          "name": "padavali_puzzles_listed_updated_at_idx",
+          "columns": [
+            {
+              "expression": "listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "padavali_puzzles_listed_last_listed_at_idx": {
+          "name": "padavali_puzzles_listed_last_listed_at_idx",
+          "columns": [
+            {
+              "expression": "listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_listed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "padavali_puzzles_image_id_image_assets_id_fk": {
+          "name": "padavali_puzzles_image_id_image_assets_id_fk",
+          "tableFrom": "padavali_puzzles",
+          "tableTo": "image_assets",
+          "columnsFrom": [
+            "image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.padavali_redirects": {
+      "name": "padavali_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "puzzle_id": {
+          "name": "puzzle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "padavali_redirects_puzzle_id_padavali_puzzles_id_fk": {
+          "name": "padavali_redirects_puzzle_id_padavali_puzzles_id_fk",
+          "tableFrom": "padavali_redirects",
+          "tableTo": "padavali_puzzles",
+          "columnsFrom": [
+            "puzzle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "padavali_redirects_slug_unique": {
+          "name": "padavali_redirects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.padavali_schedules": {
+      "name": "padavali_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "puzzle_id": {
+          "name": "puzzle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_verify_key": {
+          "name": "listing_verify_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_key": {
+          "name": "notification_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "padavali_schedules_start_time_end_time_idx": {
+          "name": "padavali_schedules_start_time_end_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "padavali_schedules_end_time_idx": {
+          "name": "padavali_schedules_end_time_idx",
+          "columns": [
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "padavali_schedules_puzzle_id_created_at_idx": {
+          "name": "padavali_schedules_puzzle_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "puzzle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "padavali_schedules_created_at_idx": {
+          "name": "padavali_schedules_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "padavali_schedules_puzzle_id_padavali_puzzles_id_fk": {
+          "name": "padavali_schedules_puzzle_id_padavali_puzzles_id_fk",
+          "tableFrom": "padavali_schedules",
+          "tableTo": "padavali_puzzles",
+          "columnsFrom": [
+            "puzzle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.padavali_sessions": {
+      "name": "padavali_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "puzzle_id": {
+          "name": "puzzle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_mode": {
+          "name": "practice_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(25)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "padavali_sessions_puzzle_id_created_at_idx": {
+          "name": "padavali_sessions_puzzle_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "puzzle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "padavali_sessions_puzzle_id_padavali_puzzles_id_fk": {
+          "name": "padavali_sessions_puzzle_id_padavali_puzzles_id_fk",
+          "tableFrom": "padavali_sessions",
+          "tableTo": "padavali_puzzles",
+          "columnsFrom": [
+            "puzzle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crossword_attachments": {
+      "name": "crossword_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "puzzle_id": {
+          "name": "puzzle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "attachment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "crossword_attachments_puzzle_id_idx": {
+          "name": "crossword_attachments_puzzle_id_idx",
+          "columns": [
+            {
+              "expression": "puzzle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crossword_attachments_puzzle_id_crossword_puzzles_id_fk": {
+          "name": "crossword_attachments_puzzle_id_crossword_puzzles_id_fk",
+          "tableFrom": "crossword_attachments",
+          "tableTo": "crossword_puzzles",
+          "columnsFrom": [
+            "puzzle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crossword_gameplay_stats": {
+      "name": "crossword_gameplay_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "puzzle_id": {
+          "name": "puzzle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "time_taken": {
+          "name": "time_taken",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accuracy": {
+          "name": "accuracy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_entries": {
+          "name": "total_entries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cells": {
+          "name": "total_cells",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefilled_cells": {
+          "name": "prefilled_cells",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "letter_inputs": {
+          "name": "letter_inputs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incorrect_entry_attempts": {
+          "name": "incorrect_entry_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "crossword_gameplay_stats_puzzle_id_created_at_idx": {
+          "name": "crossword_gameplay_stats_puzzle_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "puzzle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crossword_gameplay_stats_session_id_idx": {
+          "name": "crossword_gameplay_stats_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crossword_gameplay_stats_puzzle_id_crossword_puzzles_id_fk": {
+          "name": "crossword_gameplay_stats_puzzle_id_crossword_puzzles_id_fk",
+          "tableFrom": "crossword_gameplay_stats",
+          "tableTo": "crossword_puzzles",
+          "columnsFrom": [
+            "puzzle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "crossword_gameplay_stats_session_id_crossword_sessions_id_fk": {
+          "name": "crossword_gameplay_stats_session_id_crossword_sessions_id_fk",
+          "tableFrom": "crossword_gameplay_stats",
+          "tableTo": "crossword_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crossword_puzzles": {
+      "name": "crossword_puzzles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "grid_dimensions": {
+          "name": "grid_dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grid_data": {
+          "name": "grid_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "word_candidates": {
+          "name": "word_candidates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "word_list": {
+          "name": "word_list",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listed": {
+          "name": "listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_listed_at": {
+          "name": "last_listed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "crossword_puzzles_slug_idx": {
+          "name": "crossword_puzzles_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crossword_puzzles_listed_created_at_idx": {
+          "name": "crossword_puzzles_listed_created_at_idx",
+          "columns": [
+            {
+              "expression": "listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crossword_puzzles_listed_updated_at_idx": {
+          "name": "crossword_puzzles_listed_updated_at_idx",
+          "columns": [
+            {
+              "expression": "listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crossword_puzzles_listed_last_listed_at_idx": {
+          "name": "crossword_puzzles_listed_last_listed_at_idx",
+          "columns": [
+            {
+              "expression": "listed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_listed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crossword_puzzles_image_id_image_assets_id_fk": {
+          "name": "crossword_puzzles_image_id_image_assets_id_fk",
+          "tableFrom": "crossword_puzzles",
+          "tableTo": "image_assets",
+          "columnsFrom": [
+            "image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crossword_redirects": {
+      "name": "crossword_redirects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "puzzle_id": {
+          "name": "puzzle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "crossword_redirects_puzzle_id_crossword_puzzles_id_fk": {
+          "name": "crossword_redirects_puzzle_id_crossword_puzzles_id_fk",
+          "tableFrom": "crossword_redirects",
+          "tableTo": "crossword_puzzles",
+          "columnsFrom": [
+            "puzzle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "crossword_redirects_slug_unique": {
+          "name": "crossword_redirects_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crossword_schedules": {
+      "name": "crossword_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "puzzle_id": {
+          "name": "puzzle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_verify_key": {
+          "name": "listing_verify_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "crossword_schedules_start_time_end_time_idx": {
+          "name": "crossword_schedules_start_time_end_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crossword_schedules_end_time_idx": {
+          "name": "crossword_schedules_end_time_idx",
+          "columns": [
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crossword_schedules_puzzle_id_created_at_idx": {
+          "name": "crossword_schedules_puzzle_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "puzzle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "crossword_schedules_created_at_idx": {
+          "name": "crossword_schedules_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crossword_schedules_puzzle_id_crossword_puzzles_id_fk": {
+          "name": "crossword_schedules_puzzle_id_crossword_puzzles_id_fk",
+          "tableFrom": "crossword_schedules",
+          "tableTo": "crossword_puzzles",
+          "columnsFrom": [
+            "puzzle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crossword_sessions": {
+      "name": "crossword_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "puzzle_id": {
+          "name": "puzzle_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(25)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "crossword_sessions_puzzle_id_created_at_idx": {
+          "name": "crossword_sessions_puzzle_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "puzzle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crossword_sessions_puzzle_id_crossword_puzzles_id_fk": {
+          "name": "crossword_sessions_puzzle_id_crossword_puzzles_id_fk",
+          "tableFrom": "crossword_sessions",
+          "tableTo": "crossword_puzzles",
+          "columnsFrom": [
+            "puzzle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.attachment_type": {
+      "name": "attachment_type",
+      "schema": "public",
+      "values": [
+        "link",
+        "youtube_video",
+        "youtube_playlist",
+        "youtube_embed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/0019_snapshot.json
+++ b/src/db/migrations/meta/0019_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "41e550c1-38f7-4fd5-a107-134a531f8323",
+  "id": "8ee27103-4acd-4be4-b5f7-089b96dd2093",
   "prevId": "2389eb0d-5b50-44c6-9928-6840590fb1f9",
   "version": "7",
   "dialect": "postgresql",
@@ -417,12 +417,6 @@
         "updated_at": {
           "name": "updated_at",
           "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "word_candidates": {
-          "name": "word_candidates",
-          "type": "jsonb",
           "primaryKey": false,
           "notNull": false
         },
@@ -1139,12 +1133,6 @@
           "type": "jsonb",
           "primaryKey": false,
           "notNull": true
-        },
-        "word_candidates": {
-          "name": "word_candidates",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
         },
         "word_list": {
           "name": "word_list",

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -138,8 +138,8 @@
     {
       "idx": 19,
       "version": "7",
-      "when": 1785932941771,
-      "tag": "0019_uneven_marvel_boy",
+      "when": 1785933507505,
+      "tag": "0019_spooky_unus",
       "breakpoints": true
     }
   ]

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1784268325953,
       "tag": "0018_worthless_union_jack",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1785932941771,
+      "tag": "0019_uneven_marvel_boy",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/crossword_schema.ts
+++ b/src/db/schema/crossword_schema.ts
@@ -28,13 +28,6 @@ export const crossword_puzzles = pgTable(
     grid_dimensions: jsonb().notNull().$type<[number, number]>(),
     /** Blank text = blocked box; letter cells are playable (is_visible = prefilled hint). */
     grid_data: jsonb().notNull().$type<CrossordPuzzleGridCell[][]>(),
-    word_candidates: jsonb().$type<
-      {
-        word: string;
-        /** Added to `word_list` */
-        added: boolean;
-      }[]
-    >(),
     word_list: jsonb().notNull().$type<CrossWordPuzzleWord[]>(),
     /** Whether the puzzle is listed publicly on the website */
     listed: boolean().notNull().default(false),

--- a/src/db/schema/crossword_schema.ts
+++ b/src/db/schema/crossword_schema.ts
@@ -28,6 +28,13 @@ export const crossword_puzzles = pgTable(
     grid_dimensions: jsonb().notNull().$type<[number, number]>(),
     /** Blank text = blocked box; letter cells are playable (is_visible = prefilled hint). */
     grid_data: jsonb().notNull().$type<CrossordPuzzleGridCell[][]>(),
+    word_candidates: jsonb().$type<
+      {
+        word: string;
+        /** Added to `word_list` */
+        added: boolean;
+      }[]
+    >(),
     word_list: jsonb().notNull().$type<CrossWordPuzzleWord[]>(),
     /** Whether the puzzle is listed publicly on the website */
     listed: boolean().notNull().default(false),

--- a/src/db/schema/padavali_schema.ts
+++ b/src/db/schema/padavali_schema.ts
@@ -24,6 +24,14 @@ export const padavali_puzzles = pgTable(
     description: text().notNull().default(''),
     created_at: timestamp({ withTimezone: true }).notNull().defaultNow(),
     updated_at: timestamp({ withTimezone: true }).$onUpdate(() => new Date()), // NULL for not updated
+    word_candidates: jsonb().$type<
+      {
+        word: string;
+        /** Added to `word_list` */
+        added: boolean;
+      }[]
+    >(),
+    /** final word list */
     word_list: jsonb().notNull().$type<string[]>(),
     grid_data: jsonb().notNull().$type<string[][]>(),
     grid_dimensions: jsonb().notNull().$type<[number, number]>(),

--- a/src/db/schema/padavali_schema.ts
+++ b/src/db/schema/padavali_schema.ts
@@ -24,15 +24,12 @@ export const padavali_puzzles = pgTable(
     description: text().notNull().default(''),
     created_at: timestamp({ withTimezone: true }).notNull().defaultNow(),
     updated_at: timestamp({ withTimezone: true }).$onUpdate(() => new Date()), // NULL for not updated
-    word_candidates: jsonb().$type<
+    word_list: jsonb().notNull().$type<
       {
         word: string;
-        /** Added to `word_list` */
         added: boolean;
       }[]
     >(),
-    /** final word list */
-    word_list: jsonb().notNull().$type<string[]>(),
     grid_data: jsonb().notNull().$type<string[][]>(),
     grid_dimensions: jsonb().notNull().$type<[number, number]>(),
     /** Whether the puzzle is listed publicly on the website */

--- a/src/db/schema_zod.ts
+++ b/src/db/schema_zod.ts
@@ -22,13 +22,12 @@ import { script_list_enum } from '~/state/script_list';
 import { batch_metadata_schema } from '~/util/types/ai_batch_metadata';
 
 export const PadavaliPuzzleSchemaZod = createSelectSchema(padavali_puzzles, {
-  word_candidates: z
+  word_list: z
     .object({
       word: z.string(),
       added: z.boolean()
     })
     .array(),
-  word_list: z.string().array(),
   grid_data: z.string().array().array(),
   grid_dimensions: z.tuple([z.number().int().min(3), z.number().int().min(3)]),
   created_at: z.coerce.date(),

--- a/src/db/schema_zod.ts
+++ b/src/db/schema_zod.ts
@@ -22,6 +22,12 @@ import { script_list_enum } from '~/state/script_list';
 import { batch_metadata_schema } from '~/util/types/ai_batch_metadata';
 
 export const PadavaliPuzzleSchemaZod = createSelectSchema(padavali_puzzles, {
+  word_candidates: z
+    .object({
+      word: z.string(),
+      added: z.boolean()
+    })
+    .array(),
   word_list: z.string().array(),
   grid_data: z.string().array().array(),
   grid_dimensions: z.tuple([z.number().int().min(3), z.number().int().min(3)]),
@@ -33,6 +39,8 @@ export const PadavaliPuzzleSchemaZod = createSelectSchema(padavali_puzzles, {
 export const CrossWordPuzzleWordSchema = z.object({
   /** Only word is filled in manually, location and direction are calculated auto */
   word: z.string(),
+  /** approved to be displayed in word list to the user */
+  added: z.boolean(),
   /** starting index in the nxn grid array */
   location: z.tuple([z.number().int().min(0), z.number().int().min(0)]),
   direction: z.enum(['horizontal', 'vertical']),

--- a/src/db/schema_zod.ts
+++ b/src/db/schema_zod.ts
@@ -21,13 +21,10 @@ import { location_list_enum } from './types';
 import { script_list_enum } from '~/state/script_list';
 import { batch_metadata_schema } from '~/util/types/ai_batch_metadata';
 
+import { padavali_word_candidate_list_schema } from '~/util/puzzle/word_list';
+
 export const PadavaliPuzzleSchemaZod = createSelectSchema(padavali_puzzles, {
-  word_list: z
-    .object({
-      word: z.string(),
-      added: z.boolean()
-    })
-    .array(),
+  word_list: padavali_word_candidate_list_schema,
   grid_data: z.string().array().array(),
   grid_dimensions: z.tuple([z.number().int().min(3), z.number().int().min(3)]),
   created_at: z.coerce.date(),
@@ -35,17 +32,27 @@ export const PadavaliPuzzleSchemaZod = createSelectSchema(padavali_puzzles, {
   last_listed_at: z.coerce.date().optional().nullable()
 });
 
-export const CrossWordPuzzleWordSchema = z.object({
-  /** Only word is filled in manually, location and direction are calculated auto */
-  word: z.string(),
-  /** approved to be displayed in word list to the user */
-  added: z.boolean(),
-  /** starting index in the nxn grid array */
-  location: z.tuple([z.number().int().min(0), z.number().int().min(0)]),
-  direction: z.enum(['horizontal', 'vertical']),
-  /** Clue shown to the player — required and non-empty */
-  description: z.string().trim().min(1, 'Clue is required')
-});
+export const CrossWordPuzzleWordSchema = z
+  .object({
+    /** Only word is filled in manually, location and direction are calculated auto */
+    word: z.string(),
+    /** approved to be displayed in word list to the user */
+    added: z.boolean().default(true),
+    /** starting index in the nxn grid array */
+    location: z.tuple([z.number().int().min(0), z.number().int().min(0)]),
+    direction: z.enum(['horizontal', 'vertical']),
+    /** Clue shown to the player — required when the word is enabled */
+    description: z.string().trim()
+  })
+  .superRefine((entry, ctx) => {
+    if (entry.added && entry.word.trim().length > 0 && entry.description.length === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Clue is required',
+        path: ['description']
+      });
+    }
+  });
 export const CrossordPuzzleGridCellSchema = z.object({
   /** Blank text = blocked box; any letter = playable cell */
   text: z.string().max(1).min(0).default(''),

--- a/src/hooks/useDebouncedSlugCheck.ts
+++ b/src/hooks/useDebouncedSlugCheck.ts
@@ -57,11 +57,7 @@ export const useDebouncedSlugCheck = (slugInput: string, options: Options = {}) 
   const normalizedSlug = enabled ? normalizeSlug(slugInput) : '';
 
   const syncStatus: SlugCheckStatus | null =
-    !enabled || !normalizedSlug
-      ? 'idle'
-      : !isValidSlugFn(normalizedSlug)
-        ? 'invalid'
-        : null;
+    !enabled || !normalizedSlug ? 'idle' : !isValidSlugFn(normalizedSlug) ? 'invalid' : null;
 
   const [checkResult, setCheckResult] = useState<AsyncCheckResult>({
     slug: '',

--- a/src/util/ai/more_hints.test.ts
+++ b/src/util/ai/more_hints.test.ts
@@ -66,24 +66,23 @@ describe('more_hints_inputs_equal', () => {
     ).toBe(false);
   });
 
-  it('ignores placement-only fields when comparing', () => {
-    // more_hints_inputs_equal only accepts word + description; callers strip placement.
+  it('ignores disabled words when comparing more-hints inputs', () => {
     expect(
       more_hints_inputs_equal(
         {
           title: base.title,
           description: base.description,
           word_list: [
-            { word: 'शिव', description: 'Destroyer' },
-            { word: 'विष्णु', description: 'Preserver' }
+            { word: 'शिव', description: 'Destroyer', added: true },
+            { word: 'ब्रह्मा', description: 'Creator', added: false }
           ]
         },
         {
           title: base.title,
           description: base.description,
           word_list: [
-            { word: 'शिव', description: 'Destroyer' },
-            { word: 'विष्णु', description: 'Preserver' }
+            { word: 'शिव', description: 'Destroyer', added: true },
+            { word: 'इंद्र', description: 'King of gods', added: false }
           ]
         }
       )

--- a/src/util/ai/more_hints.ts
+++ b/src/util/ai/more_hints.ts
@@ -4,6 +4,7 @@ import type { CrossWordPuzzleWord } from '~/db/schema_zod';
 import { AiProvider, aiRetryPolicy } from '~/effect/ai';
 import { AiProviderError } from '~/effect/errors';
 import { OPENROUTER_MODELS } from '~/util/ai/image_gen';
+import { crosswordActiveWords } from '~/util/puzzle/word_list';
 
 /** Minimal puzzle shape needed to generate more hints. */
 type MoreHintsPuzzleInput = {
@@ -51,17 +52,19 @@ export const more_hints_schema = z.object({
 export type MoreHintsType = z.infer<typeof more_hints_schema>;
 
 /** Fields that affect AI more-hints generation (placement is ignored). */
-export type MoreHintsInputWord = Pick<CrossWordPuzzleWord, 'word' | 'description'>;
+export type MoreHintsInputWord = Pick<CrossWordPuzzleWord, 'word' | 'description'> &
+  Partial<Pick<CrossWordPuzzleWord, 'added'>>;
 
 export const more_hints_inputs_equal = (
   a: { title: string; description: string; word_list: MoreHintsInputWord[] },
   b: { title: string; description: string; word_list: MoreHintsInputWord[] }
 ) => {
   if (a.title !== b.title || a.description !== b.description) return false;
-  if (a.word_list.length !== b.word_list.length) return false;
-  return a.word_list.every(
-    (entry, i) =>
-      entry.word === b.word_list[i]?.word && entry.description === b.word_list[i]?.description
+  const aWords = a.word_list.filter((entry) => entry.added !== false);
+  const bWords = b.word_list.filter((entry) => entry.added !== false);
+  if (aWords.length !== bWords.length) return false;
+  return aWords.every(
+    (entry, i) => entry.word === bWords[i]?.word && entry.description === bWords[i]?.description
   );
 };
 
@@ -69,7 +72,8 @@ export const get_crossword_more_hints = Effect.fn('get_crossword_more_hints')(fu
   puzzle: MoreHintsPuzzleInput
 ) {
   const ai = yield* AiProvider;
-  const entries = puzzle.word_list
+  const activeWords = crosswordActiveWords(puzzle.word_list);
+  const entries = activeWords
     .map((entry, i) => `${i + 1}. Answer: ${entry.word}\n   Short clue: ${entry.description}`)
     .join('\n');
 
@@ -84,13 +88,13 @@ export const get_crossword_more_hints = Effect.fn('get_crossword_more_hints')(fu
       openrouterReasoningEffort: 'medium'
     });
 
-    if (result.hints.length !== puzzle.word_list.length) {
+    if (result.hints.length !== activeWords.length) {
       return yield* Effect.fail(
         AiProviderError.make({
           operation: 'more_hints',
           provider: 'openrouter',
           cause: new Error(
-            `More hints count mismatch for slug: ${puzzle.slug} (expected ${puzzle.word_list.length}, got ${result.hints.length})`
+            `More hints count mismatch for slug: ${puzzle.slug} (expected ${activeWords.length}, got ${result.hints.length})`
           )
         })
       );

--- a/src/util/cache.server/crossword_cache.ts
+++ b/src/util/cache.server/crossword_cache.ts
@@ -2,7 +2,11 @@ import { Effect } from 'effect';
 import { sql } from 'drizzle-orm';
 import { z } from 'zod';
 import { attachment_schema, image_schema } from '~/db/db_shared_vals';
-import { CrossWordPuzzleWordSchema, CrossordPuzzleGridCellSchema } from '~/db/schema_zod';
+import {
+  CrossWordPuzzleWordSchema,
+  CrossordPuzzleGridCellSchema,
+  type CrossWordPuzzleWord
+} from '~/db/schema_zod';
 import { createCache, type CacheItem, type NoCacheParams } from '~/effect/cache';
 import { dbRun } from '~/effect/database';
 import { BadRequestError, CacheError } from '~/effect/errors';
@@ -11,6 +15,7 @@ import {
   more_hints_schema,
   type MoreHintsType
 } from '~/util/ai/more_hints';
+import { crosswordActiveWordList } from '~/util/puzzle/word_list';
 
 const crossword_puzzle_schema = z.object({
   id: z.number().int(),
@@ -28,6 +33,11 @@ const crossword_puzzle_schema = z.object({
 });
 
 export type CrosswordPuzzleType = z.infer<typeof crossword_puzzle_schema>;
+
+const toPublicCrosswordPuzzle = <T extends { word_list: CrossWordPuzzleWord[] }>(puzzle: T): T => ({
+  ...puzzle,
+  word_list: crosswordActiveWordList(puzzle.word_list)
+});
 
 const current_schedule_schema = z.object({
   id: z.number().int(),
@@ -137,7 +147,17 @@ const load_current_schedule: CacheItem<NoCacheParams, CrosswordCurrentScheduleTy
           }
         }
       })
-    ).pipe(Effect.mapError(toCacheError('fetchCurrentSchedule', CURRENT_SCHEDULE_KEY)));
+    ).pipe(
+      Effect.map((schedule) =>
+        schedule
+          ? {
+              ...schedule,
+              puzzle: toPublicCrosswordPuzzle(schedule.puzzle)
+            }
+          : undefined
+      ),
+      Effect.mapError(toCacheError('fetchCurrentSchedule', CURRENT_SCHEDULE_KEY))
+    );
   }
 });
 
@@ -231,7 +251,10 @@ const load_word_puzzle: CacheItem<CrosswordPuzzleParams, CrosswordPuzzleType | u
             }
           }
         })
-      ).pipe(Effect.mapError(toCacheError('fetchWordPuzzle', wordPuzzleKey(slug))))
+      ).pipe(
+        Effect.map((puzzle) => (puzzle ? toPublicCrosswordPuzzle(puzzle) : undefined)),
+        Effect.mapError(toCacheError('fetchWordPuzzle', wordPuzzleKey(slug)))
+      )
   });
 
 const load_more_hints: CacheItem<CrosswordPuzzleParams, MoreHintsType> = createCache({

--- a/src/util/cache.server/padavali_cache.ts
+++ b/src/util/cache.server/padavali_cache.ts
@@ -10,9 +10,19 @@ import {
   word_meanings_schema,
   type WordMeaningsType
 } from '../ai/word_meanings';
+import { padavaliActiveWords, type PadavaliWordCandidate } from '~/util/puzzle/word_list';
 
 type PadavaliPuzzleType = z.infer<typeof puzzle_schema>;
 export type { PadavaliPuzzleType };
+
+type PadavaliDbPuzzle = Omit<PadavaliPuzzleType, 'word_list'> & {
+  word_list: PadavaliWordCandidate[];
+};
+
+const toPublicPadavaliPuzzle = (puzzle: PadavaliDbPuzzle): PadavaliPuzzleType => ({
+  ...puzzle,
+  word_list: padavaliActiveWords(puzzle.word_list)
+});
 
 const current_schedule_schema = z.object({
   id: z.number().int(),
@@ -122,7 +132,17 @@ const load_current_schedule: CacheItem<NoCacheParams, PadavaliCurrentScheduleTyp
           }
         }
       })
-    ).pipe(Effect.mapError(toCacheError('fetchCurrentSchedule', CURRENT_SCHEDULE_KEY)));
+    ).pipe(
+      Effect.map((schedule) =>
+        schedule
+          ? {
+              ...schedule,
+              puzzle: toPublicPadavaliPuzzle(schedule.puzzle as PadavaliDbPuzzle)
+            }
+          : undefined
+      ),
+      Effect.mapError(toCacheError('fetchCurrentSchedule', CURRENT_SCHEDULE_KEY))
+    );
   }
 });
 
@@ -216,7 +236,12 @@ const load_word_puzzle: CacheItem<PadavaliPuzzleParams, PadavaliPuzzleType | und
             }
           }
         })
-      ).pipe(Effect.mapError(toCacheError('fetchWordPuzzle', wordPuzzleKey(slug))))
+      ).pipe(
+        Effect.map((puzzle) =>
+          puzzle ? toPublicPadavaliPuzzle(puzzle as PadavaliDbPuzzle) : undefined
+        ),
+        Effect.mapError(toCacheError('fetchWordPuzzle', wordPuzzleKey(slug)))
+      )
   });
 
 const load_word_meanings: CacheItem<PadavaliPuzzleParams, WordMeaningsType> = createCache({

--- a/src/util/cross_word/adapter.ts
+++ b/src/util/cross_word/adapter.ts
@@ -6,6 +6,7 @@ import {
   type CrossWordGamePuzzle
 } from './game_model';
 import { cellHasLetter } from './grid';
+import { crosswordActiveWords } from '~/util/puzzle/word_list';
 
 export function dbDirectionToGame(direction: CrossWordPuzzleWord['direction']): CrossWordDirection {
   return direction === 'horizontal' ? 'across' : 'down';
@@ -49,6 +50,6 @@ export function toCrossWordGamePuzzle(puzzle: CrossordPuzzle): CrossWordGamePuzz
     description: puzzle.description,
     dimensions: puzzle.grid_dimensions,
     grid: puzzle.grid_data.map((row) => row.map(gridCellToGameCell)),
-    entries: puzzle.word_list.map(wordToEntry)
+    entries: crosswordActiveWords(puzzle.word_list).map(wordToEntry)
   };
 }

--- a/src/util/cross_word/placement.test.ts
+++ b/src/util/cross_word/placement.test.ts
@@ -11,7 +11,12 @@ import {
   CROSSWORD_MIN_DIM,
   CROSSWORD_MAX_DIM
 } from './grid';
-import { analyzeWordPlacements, findAllRuns, findPlacementsForWord } from './placement';
+import {
+  analyzeWordPlacements,
+  findAllRuns,
+  findPlacementsForWord,
+  resolveWordListForSave
+} from './placement';
 import { toCrossWordGamePuzzle, gridCellToGameCell } from './adapter';
 import {
   numberEntries,
@@ -78,16 +83,68 @@ describe('placement analysis', () => {
       [box(), box(), box()],
       [box(), box(), box()]
     ];
-    const analysis = analyzeWordPlacements(grid, [{ word: 'CAT', description: 'feline' }]);
+    const analysis = analyzeWordPlacements(grid, [
+      { word: 'CAT', description: 'feline', added: true }
+    ]);
     expect(analysis.hasAllValid).toBe(true);
     expect(analysis.canList).toBe(true);
     expect(analysis.noVisibleHintWords).toHaveLength(0);
     expect(analysis.resolvedWordList[0]).toMatchObject({
       word: 'CAT',
       location: [0, 0],
-      direction: 'horizontal'
+      direction: 'horizontal',
+      added: true
     });
     expect(analysis.occupiedCells.has('0,0')).toBe(true);
+  });
+
+  it('skips disabled words for validation and listing', () => {
+    const grid = [
+      [letter('C', true), letter('A'), letter('T')],
+      [box(), box(), box()],
+      [box(), box(), box()]
+    ];
+    const analysis = analyzeWordPlacements(grid, [
+      { word: 'CAT', description: 'feline', added: true },
+      { word: 'DOG', description: 'canine', added: false }
+    ]);
+    expect(analysis.statuses[0]?.status).toBe('ok');
+    expect(analysis.statuses[1]?.status).toBe('empty');
+    expect(analysis.canList).toBe(true);
+    expect(analysis.resolvedWordList).toHaveLength(1);
+  });
+
+  it('preserves added=false when resolving for save', () => {
+    const grid = [
+      [letter('C', true), letter('A'), letter('T')],
+      [box(), box(), box()],
+      [box(), box(), box()]
+    ];
+    const resolved = resolveWordListForSave(grid, [
+      {
+        word: 'CAT',
+        description: 'feline',
+        location: [0, 0],
+        direction: 'horizontal',
+        added: true
+      },
+      {
+        word: 'XYZ',
+        description: '',
+        location: [0, 0],
+        direction: 'horizontal',
+        added: false
+      }
+    ]);
+    expect(resolved[0]).toMatchObject({
+      word: 'CAT',
+      added: true,
+      location: [0, 0]
+    });
+    expect(resolved[1]).toMatchObject({
+      word: 'XYZ',
+      added: false
+    });
   });
 
   it('warns when found word has no visible letter', () => {
@@ -219,7 +276,8 @@ describe('adapter and game model', () => {
           word: 'CAT',
           location: [0, 0],
           direction: 'horizontal',
-          description: 'feline'
+          description: 'feline',
+          added: true
         }
       ],
       listed: true,

--- a/src/util/cross_word/placement.ts
+++ b/src/util/cross_word/placement.ts
@@ -133,19 +133,22 @@ function isContainedWithin(placement: WordPlacement, containingPlacement: WordPl
 /**
  * Analyze word_list against grid. Only words with exactly one matching
  * horizontal/vertical path get a resolved location/direction.
+ * Entries with `added === false` are skipped (treated as empty for validation).
  */
 export function analyzeWordPlacements(
   grid: CrossordPuzzleGridCell[][],
-  wordList: Pick<CrossWordPuzzleWord, 'word' | 'description'>[]
+  wordList: (Pick<CrossWordPuzzleWord, 'word' | 'description'> &
+    Partial<Pick<CrossWordPuzzleWord, 'added'>>)[]
 ): PlacementAnalysis {
   const statuses: (WordPlacementStatus | undefined)[] = [];
   const occupiedCells = new Set<string>();
   const noVisibleHintWords: { wordIndex: number; word: string }[] = [];
   const resolvedLongerPlacements: WordPlacement[] = [];
 
-  // Duplicate detection across word list (case-insensitive)
+  // Duplicate detection across enabled word list (case-insensitive)
   const wordCountMap = new Map<string, number[]>();
   wordList.forEach((item, index) => {
+    if (item.added === false) return;
     const key = item.word.trim().toUpperCase();
     if (!key) return;
     if (!wordCountMap.has(key)) wordCountMap.set(key, []);
@@ -160,7 +163,8 @@ export function analyzeWordPlacements(
   }
 
   const placementOrder = wordList
-    .map((item, index) => ({ index, length: item.word.trim().length }))
+    .map((item, index) => ({ index, length: item.word.trim().length, added: item.added !== false }))
+    .filter((entry) => entry.added)
     .toSorted((a, b) => b.length - a.length || a.index - b.index);
 
   // Resolve long words first, then their potential subwords. This permits
@@ -197,6 +201,12 @@ export function analyzeWordPlacements(
     }
   }
 
+  // Mark disabled / unset entries as empty so they do not affect listing checks
+  for (let i = 0; i < wordList.length; i++) {
+    if (statuses[i] !== undefined) continue;
+    statuses[i] = { status: 'empty' };
+  }
+
   const resolvedStatuses = statuses.map((status) => status ?? { status: 'empty' as const });
   const resolvedWordList: CrossWordPuzzleWord[] = [];
 
@@ -213,7 +223,8 @@ export function analyzeWordPlacements(
       word,
       location: status.placement.location,
       direction: status.placement.direction,
-      description: item.description.trim()
+      description: item.description.trim(),
+      added: true
     });
   }
 
@@ -252,24 +263,28 @@ export function analyzeWordPlacements(
 /** Resolve word_list placements for persistence; keeps unresolved words with placeholder location. */
 export function resolveWordListForSave(
   grid: CrossordPuzzleGridCell[][],
-  wordList: Pick<CrossWordPuzzleWord, 'word' | 'description' | 'location' | 'direction'>[]
+  wordList: (Pick<CrossWordPuzzleWord, 'word' | 'description' | 'location' | 'direction'> &
+    Partial<Pick<CrossWordPuzzleWord, 'added'>>)[]
 ): CrossWordPuzzleWord[] {
   const analysis = analyzeWordPlacements(grid, wordList);
   return wordList.map((item, i) => {
+    const added = item.added ?? true;
     const status = analysis.statuses[i];
     if (status?.status === 'ok') {
       return {
         word: item.word.trim().toUpperCase(),
         location: status.placement.location,
         direction: status.placement.direction,
-        description: item.description.trim()
+        description: item.description.trim(),
+        added
       };
     }
     return {
       word: item.word.trim().toUpperCase(),
       location: item.location ?? [0, 0],
       direction: item.direction ?? 'horizontal',
-      description: item.description.trim()
+      description: item.description.trim(),
+      added
     };
   });
 }

--- a/src/util/puzzle/word_list.test.ts
+++ b/src/util/puzzle/word_list.test.ts
@@ -11,6 +11,12 @@ describe('padavaliActiveWords', () => {
       ])
     ).toEqual(['राम', 'लक्ष्मण']);
   });
+
+  it('treats missing added as enabled', () => {
+    expect(padavaliActiveWords([{ word: 'राम' }, { word: 'सीता', added: false }])).toEqual([
+      'राम'
+    ]);
+  });
 });
 
 describe('padavaliActiveWordsEqual', () => {
@@ -44,5 +50,11 @@ describe('crosswordActiveWords', () => {
         { word: 'DOG', added: false }
       ])
     ).toEqual([{ word: 'CAT', added: true }]);
+  });
+
+  it('keeps entries when added is missing', () => {
+    expect(crosswordActiveWords([{ word: 'CAT' }, { word: 'DOG', added: false }])).toEqual([
+      { word: 'CAT' }
+    ]);
   });
 });

--- a/src/util/puzzle/word_list.test.ts
+++ b/src/util/puzzle/word_list.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { crosswordActiveWords, padavaliActiveWords, padavaliActiveWordsEqual } from './word_list';
+
+describe('padavaliActiveWords', () => {
+  it('returns only enabled words in order', () => {
+    expect(
+      padavaliActiveWords([
+        { word: 'राम', added: true },
+        { word: 'सीता', added: false },
+        { word: 'लक्ष्मण', added: true }
+      ])
+    ).toEqual(['राम', 'लक्ष्मण']);
+  });
+});
+
+describe('padavaliActiveWordsEqual', () => {
+  it('ignores disabled candidates when comparing', () => {
+    expect(
+      padavaliActiveWordsEqual(
+        [
+          { word: 'राम', added: true },
+          { word: 'सीता', added: false }
+        ],
+        [
+          { word: 'राम', added: true },
+          { word: 'हनुमान', added: false }
+        ]
+      )
+    ).toBe(true);
+  });
+
+  it('detects enabled word changes', () => {
+    expect(
+      padavaliActiveWordsEqual([{ word: 'राम', added: true }], [{ word: 'सीता', added: true }])
+    ).toBe(false);
+  });
+});
+
+describe('crosswordActiveWords', () => {
+  it('filters to added entries', () => {
+    expect(
+      crosswordActiveWords([
+        { word: 'CAT', added: true },
+        { word: 'DOG', added: false }
+      ])
+    ).toEqual([{ word: 'CAT', added: true }]);
+  });
+});

--- a/src/util/puzzle/word_list.test.ts
+++ b/src/util/puzzle/word_list.test.ts
@@ -13,9 +13,7 @@ describe('padavaliActiveWords', () => {
   });
 
   it('treats missing added as enabled', () => {
-    expect(padavaliActiveWords([{ word: 'राम' }, { word: 'सीता', added: false }])).toEqual([
-      'राम'
-    ]);
+    expect(padavaliActiveWords([{ word: 'राम' }, { word: 'सीता', added: false }])).toEqual(['राम']);
   });
 });
 

--- a/src/util/puzzle/word_list.ts
+++ b/src/util/puzzle/word_list.ts
@@ -12,22 +12,27 @@ export type PadavaliWordCandidate = z.infer<typeof padavali_word_candidate_schem
 
 export const padavali_word_candidate_list_schema = padavali_word_candidate_schema.array();
 
+/** Missing `added` is treated as enabled (safe default for any stale payloads). */
+export function isWordAdded(entry: { added?: boolean }): boolean {
+  return entry.added !== false;
+}
+
 /** Active (enabled) Padavali words as the public `string[]` contract */
 export function padavaliActiveWords(
-  wordList: readonly Pick<PadavaliWordCandidate, 'word' | 'added'>[]
+  wordList: readonly (Pick<PadavaliWordCandidate, 'word'> & { added?: boolean })[]
 ): string[] {
-  return wordList.filter((entry) => entry.added).map((entry) => entry.word);
+  return wordList.filter(isWordAdded).map((entry) => entry.word);
 }
 
 /** Active crossword entries for public play / listing validation */
-export function crosswordActiveWords<T extends { added: boolean }>(wordList: readonly T[]): T[] {
-  return wordList.filter((entry) => entry.added);
+export function crosswordActiveWords<T extends { added?: boolean }>(wordList: readonly T[]): T[] {
+  return wordList.filter(isWordAdded);
 }
 
 /** Compare enabled Padavali word sequences (order-sensitive) */
 export function padavaliActiveWordsEqual(
-  a: readonly Pick<PadavaliWordCandidate, 'word' | 'added'>[],
-  b: readonly Pick<PadavaliWordCandidate, 'word' | 'added'>[]
+  a: readonly (Pick<PadavaliWordCandidate, 'word'> & { added?: boolean })[],
+  b: readonly (Pick<PadavaliWordCandidate, 'word'> & { added?: boolean })[]
 ): boolean {
   const left = padavaliActiveWords(a);
   const right = padavaliActiveWords(b);

--- a/src/util/puzzle/word_list.ts
+++ b/src/util/puzzle/word_list.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import type { CrossWordPuzzleWord } from '~/db/schema_zod';
+
+/** Padavali editor/DB word candidate */
+export const padavali_word_candidate_schema = z.object({
+  word: z.string(),
+  /** When true, the word is included in the public puzzle */
+  added: z.boolean().default(true)
+});
+
+export type PadavaliWordCandidate = z.infer<typeof padavali_word_candidate_schema>;
+
+export const padavali_word_candidate_list_schema = padavali_word_candidate_schema.array();
+
+/** Active (enabled) Padavali words as the public `string[]` contract */
+export function padavaliActiveWords(
+  wordList: readonly Pick<PadavaliWordCandidate, 'word' | 'added'>[]
+): string[] {
+  return wordList.filter((entry) => entry.added).map((entry) => entry.word);
+}
+
+/** Active crossword entries for public play / listing validation */
+export function crosswordActiveWords<T extends { added: boolean }>(wordList: readonly T[]): T[] {
+  return wordList.filter((entry) => entry.added);
+}
+
+/** Compare enabled Padavali word sequences (order-sensitive) */
+export function padavaliActiveWordsEqual(
+  a: readonly Pick<PadavaliWordCandidate, 'word' | 'added'>[],
+  b: readonly Pick<PadavaliWordCandidate, 'word' | 'added'>[]
+): boolean {
+  const left = padavaliActiveWords(a);
+  const right = padavaliActiveWords(b);
+  return left.length === right.length && left.every((word, i) => word === right[i]);
+}
+
+/** Project a DB/editor crossword word list down to public-facing active entries */
+export function crosswordActiveWordList(
+  wordList: readonly CrossWordPuzzleWord[]
+): CrossWordPuzzleWord[] {
+  return crosswordActiveWords(wordList);
+}


### PR DESCRIPTION
- **init - format**
- **schema diff  init**
- **Refactor Padavali and Crossword Puzzle Schemas**
- **Enhance Padavali and Crossword Puzzle Functionality**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controls to enable or exclude individual Padavali and crossword words while editing puzzles.
  * Excluded words are visually muted and omitted from gameplay, previews, placement checks, and hint generation.
  * Crossword clues are required only for enabled words.

* **Bug Fixes**
  * Puzzle lists, statistics, and cached data now count and display only active words.
  * Disabled words no longer affect word comparisons or validation.

* **Style**
  * Applied minor formatting and interface styling updates.
  * Improved hint dialog guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->