### PR TITLE
feat: Add layout Generator in Padavali and add colour  indicator for grid in padajala

### DIFF
--- a/src/components/pages/cross_word/ViewEditCrossword.tsx
+++ b/src/components/pages/cross_word/ViewEditCrossword.tsx
@@ -114,6 +114,13 @@ import { Badge } from '~/components/ui/badge';
 import { Checkbox } from '~/components/ui/checkbox';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { isWordAdded } from '~/util/puzzle/word_list';
+import {
+  cellWordTintAppearance,
+  getWordColorPair,
+  wordColorCssVars,
+  wordColorSwatchClassName
+} from '~/util/puzzle/word_colors';
+import type { WordPlacementStatus } from '~/util/cross_word/placement';
 
 const BASE_SCRIPT = 'Devanagari';
 
@@ -126,6 +133,24 @@ type EditableWord = {
   direction: CrossWordPuzzleWord['direction'];
   added: boolean;
 };
+
+/**
+ * Soft word tint by slot index for uniquely resolved placements.
+ * Intersections keep the first word’s color (no conflict red — normal for crossword).
+ */
+function buildCrosswordCellWordSlots(
+  statuses: readonly WordPlacementStatus[]
+): Map<string, number> {
+  const slots = new Map<string, number>();
+  statuses.forEach((status, wordIndex) => {
+    if (status.status !== 'ok') return;
+    for (const [r, c] of status.placement.cells) {
+      const key = `${r},${c}`;
+      if (!slots.has(key)) slots.set(key, wordIndex);
+    }
+  });
+  return slots;
+}
 
 type EditableAttachment = Omit<z.infer<typeof attachment_schema>, 'id'> & {
   id: number | null;
@@ -673,6 +698,9 @@ const DimensionsField = () => {
 type CrosswordWordRowProps = {
   item: EditableWord;
   originalIndex: number;
+  /** Index among currently rendered rows (for ↑↓←→ navigation). */
+  listRowIndex: number;
+  listRowCount: number;
   showSelection: boolean;
   showRemove: boolean;
   startLabel: string;
@@ -684,9 +712,29 @@ type CrosswordWordRowProps = {
   onRemove: (index: number) => void;
 };
 
+type WordListField = 'word' | 'dev' | 'clue';
+const WORD_LIST_FIELDS: WordListField[] = ['word', 'dev', 'clue'];
+
+function focusWordListInput(
+  container: ParentNode,
+  row: number,
+  field: WordListField
+): HTMLInputElement | null {
+  const el = container.querySelector<HTMLInputElement>(
+    `input[data-wl-row="${row}"][data-wl-field="${field}"]`
+  );
+  if (!el) return null;
+  el.focus();
+  const end = el.value.length;
+  el.setSelectionRange(end, end);
+  return el;
+}
+
 function CrosswordWordRow({
   item,
   originalIndex,
+  listRowIndex,
+  listRowCount,
   showSelection,
   showRemove,
   startLabel,
@@ -705,6 +753,45 @@ function CrosswordWordRow({
   const missingWordDev = isAdded && hasLatinWord && item.word_dev.trim().length === 0;
   const missingClue = isAdded && hasLatinWord && item.description.trim().length === 0;
 
+  const handleListNavKeyDown = (event: KeyboardEvent<HTMLInputElement>, field: WordListField) => {
+    const container = event.currentTarget.closest('[data-word-list]');
+    if (!container) return;
+
+    const fieldIndex = WORD_LIST_FIELDS.indexOf(field);
+    const input = event.currentTarget;
+    const start = input.selectionStart ?? 0;
+    const end = input.selectionEnd ?? 0;
+    const atStart = start === 0 && end === 0;
+    const atEnd = start === input.value.length && end === input.value.length;
+
+    const moveTo = (row: number, nextField: WordListField) => {
+      if (focusWordListInput(container, row, nextField)) {
+        event.preventDefault();
+      }
+    };
+
+    if (event.key === 'ArrowUp' && listRowIndex > 0) {
+      moveTo(listRowIndex - 1, field);
+      return;
+    }
+    if (event.key === 'ArrowDown' && listRowIndex < listRowCount - 1) {
+      moveTo(listRowIndex + 1, field);
+      return;
+    }
+    if (event.key === 'ArrowLeft' && atStart) {
+      if (fieldIndex > 0) moveTo(listRowIndex, WORD_LIST_FIELDS[fieldIndex - 1]!);
+      else if (listRowIndex > 0) moveTo(listRowIndex - 1, 'clue');
+      return;
+    }
+    if (event.key === 'ArrowRight' && atEnd) {
+      if (fieldIndex < WORD_LIST_FIELDS.length - 1) {
+        moveTo(listRowIndex, WORD_LIST_FIELDS[fieldIndex + 1]!);
+      } else if (listRowIndex < listRowCount - 1) {
+        moveTo(listRowIndex + 1, 'word');
+      }
+    }
+  };
+
   return (
     <div
       className={cn(
@@ -721,8 +808,25 @@ function CrosswordWordRow({
             className="mt-2.5 shrink-0"
           />
         ) : null}
+        {/* Always-reserved swatch — matches grid tint, no layout shift */}
+        <span
+          aria-hidden
+          className={cn(
+            'mt-3 size-2.5 shrink-0 rounded-full sm:mt-2.5',
+            wordColorSwatchClassName,
+            !isAdded && 'opacity-50'
+          )}
+          style={wordColorCssVars(getWordColorPair(originalIndex))}
+          title={`Word color ${getWordColorPair(originalIndex).id}`}
+        />
         <Input
           value={item.word}
+          data-wl-row={listRowIndex}
+          data-wl-field="word"
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="characters"
+          autoComplete="off"
           onChange={(e) =>
             onUpdate(originalIndex, {
               word: e.currentTarget.value.toUpperCase().replace(/[^A-Z]/g, '')
@@ -730,7 +834,9 @@ function CrosswordWordRow({
           }
           onFocus={wordHistoryField.onFocus}
           onBlur={wordHistoryField.onBlur}
+          onKeyDown={(event) => handleListNavKeyDown(event, 'word')}
           placeholder="WORD"
+          aria-label={`English word ${originalIndex + 1}`}
           className={cn(
             'min-w-0 flex-1 font-mono uppercase sm:w-44 sm:flex-none',
             !isAdded && 'opacity-60'
@@ -738,6 +844,8 @@ function CrosswordWordRow({
         />
         <Input
           value={item.word_dev}
+          data-wl-row={listRowIndex}
+          data-wl-field="dev"
           onChange={(e) => onUpdate(originalIndex, { word_dev: e.currentTarget.value })}
           onBeforeInput={(event) =>
             handleTypingBeforeInputEvent(
@@ -752,7 +860,10 @@ function CrosswordWordRow({
             typingContext.clearContext();
             wordDevHistoryField.onBlur();
           }}
-          onKeyDown={(event) => clearTypingContextOnKeyDown(event, typingContext)}
+          onKeyDown={(event) => {
+            clearTypingContextOnKeyDown(event, typingContext);
+            handleListNavKeyDown(event, 'dev');
+          }}
           placeholder="देवनागरी"
           required={isAdded && hasLatinWord}
           aria-invalid={missingWordDev || undefined}
@@ -769,12 +880,16 @@ function CrosswordWordRow({
       <div className="flex min-w-0 items-center gap-2 sm:contents">
         <Input
           value={item.description}
+          data-wl-row={listRowIndex}
+          data-wl-field="clue"
           onChange={(e) => onUpdate(originalIndex, { description: e.currentTarget.value })}
           onFocus={clueHistoryField.onFocus}
           onBlur={clueHistoryField.onBlur}
+          onKeyDown={(event) => handleListNavKeyDown(event, 'clue')}
           placeholder="Clue / description"
           required={isAdded && hasLatinWord}
           aria-invalid={missingClue || undefined}
+          aria-label={`Clue ${originalIndex + 1}`}
           className={cn(
             'min-w-0 flex-1',
             !isAdded && 'opacity-60',
@@ -878,6 +993,28 @@ function GeneratedLayoutPreview({ candidate }: { candidate: GeneratedCrosswordLa
   const fontSizePx = Math.max(8, Math.min(12, cellPx - 4));
   const rangeLabel = `${formatGridCellRef(firstRow, firstColumn)}–${formatGridCellRef(lastRow, lastColumn)}`;
 
+  // Color by placement order; first word wins on intersections
+  const previewTintByLocalKey = new Map<string, number>();
+  candidate.placements.forEach((placement, placementIndex) => {
+    let [r, c] = placement.location;
+    while (
+      r >= 0 &&
+      c >= 0 &&
+      r < candidate.gridData.length &&
+      c < (candidate.gridData[0]?.length ?? 0) &&
+      cellHasLetter(candidate.gridData[r]![c]!)
+    ) {
+      if (r >= firstRow && r <= lastRow && c >= firstColumn && c <= lastColumn) {
+        const localKey = `${r - firstRow},${c - firstColumn}`;
+        if (!previewTintByLocalKey.has(localKey)) {
+          previewTintByLocalKey.set(localKey, placementIndex);
+        }
+      }
+      if (placement.direction === 'horizontal') c += 1;
+      else r += 1;
+    }
+  });
+
   return (
     <div
       className="flex shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/20 p-1"
@@ -895,25 +1032,33 @@ function GeneratedLayoutPreview({ candidate }: { candidate: GeneratedCrosswordLa
         }}
       >
         {previewRows.flatMap((row, rowIndex) =>
-          row.map((cell, columnIndex) => (
-            <span
-              key={`${rowIndex}-${columnIndex}`}
-              className={cn(
-                'flex items-center justify-center overflow-hidden font-mono leading-none font-semibold',
-                cellHasLetter(cell)
-                  ? 'bg-blue-50 text-foreground dark:bg-blue-950/50'
-                  : 'bg-popover text-transparent'
-              )}
-              style={{
-                width: cellPx,
-                height: cellPx,
-                fontSize: fontSizePx,
-                lineHeight: 1
-              }}
-            >
-              {cell.text}
-            </span>
-          ))
+          row.map((cell, columnIndex) => {
+            const hasLetter = cellHasLetter(cell);
+            const slotIndex = previewTintByLocalKey.get(`${rowIndex},${columnIndex}`);
+            const tint =
+              hasLetter && slotIndex !== undefined
+                ? cellWordTintAppearance({ slotIndex, conflict: false })
+                : { className: '', style: undefined };
+            return (
+              <span
+                key={`${rowIndex}-${columnIndex}`}
+                className={cn(
+                  'flex items-center justify-center overflow-hidden font-mono leading-none font-semibold',
+                  hasLetter ? 'bg-background text-foreground' : 'bg-popover text-transparent',
+                  tint.className
+                )}
+                style={{
+                  width: cellPx,
+                  height: cellPx,
+                  fontSize: fontSizePx,
+                  lineHeight: 1,
+                  ...tint.style
+                }}
+              >
+                {cell.text}
+              </span>
+            );
+          })
         )}
       </div>
     </div>
@@ -924,12 +1069,14 @@ function WordChipList({
   ids,
   wordNames,
   emptyLabel,
-  tone = 'default'
+  tone = 'default',
+  colorById
 }: {
   ids: readonly string[];
   wordNames: ReadonlyMap<string, string>;
   emptyLabel: string;
   tone?: 'default' | 'warning';
+  colorById?: ReadonlyMap<string, number>;
 }) {
   if (ids.length === 0) {
     return <p className="text-xs text-muted-foreground">{emptyLabel}</p>;
@@ -937,21 +1084,32 @@ function WordChipList({
 
   return (
     <div className="flex flex-wrap gap-1.5">
-      {ids.map((id) => (
-        <Badge
-          key={id}
-          variant="outline"
-          className={cn(
-            'max-w-full font-mono normal-case',
-            tone === 'warning' &&
-              'border-amber-500/40 bg-amber-500/10 text-amber-800 dark:text-amber-200'
-          )}
-        >
-          <span className="truncate">
-            {wordNames.get(id)?.trim().toUpperCase() || 'Untitled word'}
-          </span>
-        </Badge>
-      ))}
+      {ids.map((id) => {
+        const colorIndex = colorById?.get(id);
+        const colorPair = colorIndex !== undefined ? getWordColorPair(colorIndex) : null;
+        return (
+          <Badge
+            key={id}
+            variant="outline"
+            className={cn(
+              'max-w-full gap-1.5 font-mono normal-case',
+              tone === 'warning' &&
+                'border-amber-500/40 bg-amber-500/10 text-amber-800 dark:text-amber-200'
+            )}
+          >
+            {tone === 'default' && colorPair ? (
+              <span
+                aria-hidden
+                className={cn('size-2 shrink-0 rounded-full', wordColorSwatchClassName)}
+                style={wordColorCssVars(colorPair)}
+              />
+            ) : null}
+            <span className="truncate">
+              {wordNames.get(id)?.trim().toUpperCase() || 'Untitled word'}
+            </span>
+          </Badge>
+        );
+      })}
     </div>
   );
 }
@@ -963,6 +1121,14 @@ function LayoutCandidateDetail({
   candidate: GeneratedCrosswordLayout;
   wordNames: ReadonlyMap<string, string>;
 }) {
+  const colorById = useMemo(() => {
+    const map = new Map<string, number>();
+    candidate.placements.forEach((placement, index) => {
+      map.set(placement.id, index);
+    });
+    return map;
+  }, [candidate.placements]);
+
   return (
     <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
       <GeneratedLayoutPreview candidate={candidate} />
@@ -978,6 +1144,7 @@ function LayoutCandidateDetail({
             ids={candidate.placedIds}
             wordNames={wordNames}
             emptyLabel="No words placed in this layout."
+            colorById={colorById}
           />
         </div>
         {candidate.omittedIds.length > 0 ? (
@@ -1456,9 +1623,12 @@ const WordListEditor = () => {
     rows: readonly { item: EditableWord; originalIndex: number }[],
     { showSelection, showRemove }: { showSelection: boolean; showRemove: boolean }
   ) => (
-    <div className="max-h-80 overflow-y-auto overscroll-contain pr-1">
+    <div className="max-h-80 overflow-y-auto overscroll-contain pr-1" data-word-list>
+      <p className="mb-2 hidden text-xs text-muted-foreground/80 sm:block">
+        Navigate fields with the arrow keys (↑ ↓ ← →)
+      </p>
       <div className="flex flex-col gap-3 sm:gap-2">
-        {rows.map(({ item, originalIndex }) => {
+        {rows.map(({ item, originalIndex }, listRowIndex) => {
           const status = analysis.statuses[originalIndex];
           const startLabel =
             status?.status === 'ok'
@@ -1476,6 +1646,8 @@ const WordListEditor = () => {
               key={item.id}
               item={item}
               originalIndex={originalIndex}
+              listRowIndex={listRowIndex}
+              listRowCount={rows.length}
               showSelection={showSelection}
               showRemove={showRemove}
               startLabel={startLabel}
@@ -1544,11 +1716,19 @@ const PlacementAndGrid = () => {
   const [dimensions] = useAtom(grid_dimensions_atom);
 
   const analysis = useMemo(() => analyzeWordPlacements(gridData, wordList), [gridData, wordList]);
+  const cellWordSlots = useMemo(
+    () => buildCrosswordCellWordSlots(analysis.statuses),
+    [analysis.statuses]
+  );
 
   return (
     <>
       <PlacementAnalysisPanel analysis={analysis} />
-      <GridEditor occupiedCells={analysis.occupiedCells} dimensions={dimensions} />
+      <GridEditor
+        occupiedCells={analysis.occupiedCells}
+        cellWordSlots={cellWordSlots}
+        dimensions={dimensions}
+      />
     </>
   );
 };
@@ -1726,9 +1906,11 @@ const PlacementAnalysisPanel = ({
 
 const GridEditor = ({
   occupiedCells,
+  cellWordSlots,
   dimensions
 }: {
   occupiedCells: Set<string>;
+  cellWordSlots: Map<string, number>;
   dimensions: [number, number];
 }) => {
   const [gridData, setGridData] = useAtom(grid_data_atom);
@@ -1771,6 +1953,7 @@ const GridEditor = ({
     );
     if (!el) return false;
     el.focus();
+    // Single-letter cells — select all so typing replaces immediately
     el.select();
     return true;
   };
@@ -1805,34 +1988,49 @@ const GridEditor = ({
     }
   };
 
-  const getCellClassName = (r: number, c: number) => {
+  const getCellAppearance = (r: number, c: number) => {
     const cell = gridData[r]?.[c];
-    if (!cell) return '';
+    if (!cell) return { className: '', style: undefined };
     const isBox = isBoxCell(cell);
     const hasLetter = cellHasLetter(cell);
     const isVisible = hasLetter && cell.is_visible;
     const isOccupied = occupiedCells.has(`${r},${c}`);
+    const slotIndex = cellWordSlots.get(`${r},${c}`);
+    // Soft word fill (background only) — status stays on border/ring
+    const tint =
+      !isBox && slotIndex !== undefined
+        ? cellWordTintAppearance({ slotIndex, conflict: false })
+        : { className: '', style: undefined };
 
-    return cn(
-      // Override default Input border/focus (often bluish) with explicit state rings.
-      'h-9 rounded border bg-transparent px-0 text-center font-mono text-sm uppercase shadow-none transition-all duration-200',
-      'focus-visible:ring-2 focus-visible:ring-offset-0',
-      isBox &&
-        'border-transparent bg-muted/50 text-muted-foreground focus-visible:ring-muted-foreground/30',
-      // Prefilled hint → green
-      isVisible &&
-        'border-emerald-500 bg-emerald-50/80 focus-visible:ring-emerald-500/40 dark:border-emerald-400 dark:bg-emerald-950/40',
-      // Covered by a word, not prefilled → Padavali-style blue
-      hasLetter &&
-        !isVisible &&
-        isOccupied &&
-        'border-blue-300/80 focus-visible:ring-blue-400/30 dark:border-blue-500/60',
-      // Letter not covered by any word → white (orphan)
-      hasLetter &&
-        !isVisible &&
-        !isOccupied &&
-        'border-white focus-visible:ring-white/40 dark:border-white/70'
-    );
+    return {
+      className: cn(
+        // Override default Input border/focus (often bluish) with explicit state rings.
+        'h-9 rounded border bg-transparent px-0 text-center font-mono text-sm uppercase shadow-none transition-all duration-200',
+        'focus-visible:ring-2 focus-visible:ring-offset-0',
+        isBox &&
+          'border-transparent bg-muted/50 text-muted-foreground focus-visible:ring-muted-foreground/30',
+        // Prefilled hint → strong green frame only (do not alter word tint background)
+        isVisible &&
+          cn(
+            'border-2 border-emerald-500',
+            'ring-2 ring-emerald-400/65',
+            'focus-visible:ring-emerald-400/80',
+            'dark:border-emerald-400 dark:ring-emerald-400/55'
+          ),
+        // Covered by a word, not prefilled → blue border/ring
+        hasLetter &&
+          !isVisible &&
+          isOccupied &&
+          'border-blue-300/80 focus-visible:ring-blue-400/30 dark:border-blue-500/60',
+        // Letter not covered by any word → white (orphan)
+        hasLetter &&
+          !isVisible &&
+          !isOccupied &&
+          'border-white focus-visible:ring-white/40 dark:border-white/70',
+        tint.className
+      ),
+      style: tint.style
+    };
   };
 
   return (
@@ -1850,7 +2048,7 @@ const GridEditor = ({
         on a letter to mark it as prefilled (soft-keyboard Enter works too).
       </p>
       <p className="hidden text-xs text-muted-foreground/80 sm:block">
-        Navigate the grid with the arrow keys (↑ ↓ ← →)
+        Navigate the grid with the arrow keys (↑ ↓ ← →). Soft cell colors match each word.
       </p>
       <div
         ref={gridRef}
@@ -1875,6 +2073,7 @@ const GridEditor = ({
             {row.map((cell, c) => {
               const isBox = isBoxCell(cell);
               const cellRef = formatGridCellRef(r, c);
+              const { className, style } = getCellAppearance(r, c);
 
               return (
                 <Input
@@ -1890,7 +2089,8 @@ const GridEditor = ({
                   onKeyDown={(e) => handleCellKeyDown(r, c, e)}
                   onFocus={historyField.onFocus}
                   onBlur={historyField.onBlur}
-                  className={getCellClassName(r, c)}
+                  className={className}
+                  style={style}
                   maxLength={2}
                   aria-label={
                     isBox
@@ -1907,16 +2107,19 @@ const GridEditor = ({
       </div>
       <div className="flex flex-wrap gap-x-5 gap-y-2 text-[11px] text-muted-foreground">
         <div className="flex h-3 items-center gap-1.5">
-          <div className="size-2 shrink-0 rounded-full bg-emerald-500" aria-hidden />
+          <div
+            className="size-2.5 shrink-0 rounded-full bg-emerald-500 ring-2 ring-emerald-400/70"
+            aria-hidden
+          />
           <span className="leading-none">Prefilled</span>
         </div>
         <div className="flex h-3 items-center gap-1.5">
           <div className="size-2 shrink-0 rounded-full bg-blue-400 dark:bg-blue-500" aria-hidden />
-          <span className="leading-none">In a word</span>
+          <span className="leading-none">In a word (border)</span>
         </div>
         <div className="flex h-3 items-center gap-1.5">
           <div className="size-2 shrink-0 rounded-full bg-white" aria-hidden />
-          <span className="leading-none">Not in any word</span>
+          <span className="leading-none">Not in any word (border)</span>
         </div>
       </div>
     </div>

--- a/src/components/pages/padavali/PadavaliLayoutGenerator.tsx
+++ b/src/components/pages/padavali/PadavaliLayoutGenerator.tsx
@@ -1,0 +1,729 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import useEmblaCarousel from 'embla-carousel-react';
+import { ChevronLeft, ChevronRight, Info, WandSparkles } from 'lucide-react';
+import { toast } from 'sonner';
+import { Badge } from '~/components/ui/badge';
+import { Button } from '~/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '~/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '~/components/ui/alert-dialog';
+import { Label } from '~/components/ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '~/components/ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '~/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
+import { cn } from '~/lib/utils';
+import { splitDevanagariAksharas } from '~/util/puzzle/devanagari_syllables';
+import {
+  generatePadavaliLayouts,
+  rankGeneratedLayouts,
+  type GeneratedPadavaliLayout,
+  type LayoutNeighborhoodMode,
+  type LayoutPathStyle,
+  type LayoutRanking
+} from '~/util/puzzle/layout_generator';
+import { isWordAdded, type PadavaliWordCandidate } from '~/util/puzzle/word_list';
+import {
+  buildCellWordColorMapFromPlacements,
+  cellWordTintAppearance,
+  getWordColorPair,
+  wordColorCssVars,
+  wordColorSwatchClassName
+} from '~/util/puzzle/word_colors';
+
+const LAYOUT_NEIGHBORHOOD_ITEMS = [
+  { value: 'all', label: 'All styles' },
+  { value: 'n8', label: 'Any neighboring cell' },
+  { value: 'n4', label: 'Up, down, left, and right' }
+] as const;
+
+const LAYOUT_PATH_STYLE_ITEMS = [
+  { value: 'flexible', label: 'Free to turn' },
+  { value: 'straight', label: 'Left to right & top to bottom' }
+] as const;
+
+const NEIGHBOR_MOVES_INFO =
+  'Which cells can be the next step in a word. “Any neighboring” includes diagonals; “up/down/left/right” is orthogonal only. “All styles” mixes both across candidates.';
+
+const WORD_ORDER_INFO =
+  'How akṣaras are ordered along each word. Free to turn may bend using neighbor moves. Left-to-right & top-to-bottom keeps every word as a straight across or down run.';
+
+const LAYOUT_RANKING_ITEMS = [
+  { value: 'words', label: 'Most words' },
+  { value: 'fill', label: 'Fewest empty cells' },
+  { value: 'compact', label: 'Most compact' }
+] as const;
+
+const LAYOUT_CANDIDATE_LIMITS = [4, 8, 12, 16, 24, 32] as const;
+type LayoutCandidateLimit = (typeof LAYOUT_CANDIDATE_LIMITS)[number];
+
+const LAYOUT_CANDIDATE_LIMIT_ITEMS = LAYOUT_CANDIDATE_LIMITS.map((limit) => ({
+  value: String(limit),
+  label: `${limit} layouts`
+}));
+
+function parseLayoutNeighborhood(value: string | null | undefined): LayoutNeighborhoodMode | null {
+  if (value === 'all' || value === 'n8' || value === 'n4') return value;
+  return null;
+}
+
+function parseLayoutPathStyle(value: string | null | undefined): LayoutPathStyle | null {
+  if (value === 'flexible' || value === 'straight') return value;
+  return null;
+}
+
+function parseLayoutRanking(value: string | null | undefined): LayoutRanking | null {
+  if (value === 'words' || value === 'fill' || value === 'compact') return value;
+  return null;
+}
+
+function parseLayoutCandidateLimit(value: string | null | undefined): LayoutCandidateLimit | null {
+  const parsed = Number(value);
+  for (const limit of LAYOUT_CANDIDATE_LIMITS) {
+    if (limit === parsed) return limit;
+  }
+  return null;
+}
+
+function layoutCandidateKey(candidate: GeneratedPadavaliLayout): string {
+  return candidate.gridData.map((row) => row.join('\0')).join('\n');
+}
+
+const LAYOUT_PREVIEW_FRAME_PX = 256;
+const LAYOUT_PREVIEW_GAP_PX = 1;
+
+function GeneratedLayoutPreview({
+  candidate,
+  gridDimensions
+}: {
+  candidate: GeneratedPadavaliLayout;
+  wordList?: readonly PadavaliWordCandidate[];
+  gridDimensions: [number, number];
+}) {
+  const [rows, cols] = gridDimensions;
+  const cellColorMap = buildCellWordColorMapFromPlacements(candidate.placements);
+  const majorSpan = Math.max(rows, cols, 1);
+  const cellPx = Math.max(
+    1,
+    Math.floor((LAYOUT_PREVIEW_FRAME_PX - (majorSpan - 1) * LAYOUT_PREVIEW_GAP_PX) / majorSpan)
+  );
+  const gridWidth = cellPx * cols + LAYOUT_PREVIEW_GAP_PX * Math.max(0, cols - 1);
+  const gridHeight = cellPx * rows + LAYOUT_PREVIEW_GAP_PX * Math.max(0, rows - 1);
+  const fontSizePx = Math.max(8, Math.min(14, cellPx - 6));
+
+  return (
+    <div
+      className="flex shrink-0 items-center justify-center rounded-md border border-border/60 bg-muted/20 p-1"
+      style={{ width: LAYOUT_PREVIEW_FRAME_PX + 10, height: LAYOUT_PREVIEW_FRAME_PX + 10 }}
+    >
+      <div
+        aria-label={`Generated ${rows} by ${cols} grid preview`}
+        className="grid bg-border/60"
+        style={{
+          width: gridWidth,
+          height: gridHeight,
+          gap: LAYOUT_PREVIEW_GAP_PX,
+          gridTemplateColumns: `repeat(${cols}, ${cellPx}px)`,
+          gridTemplateRows: `repeat(${rows}, ${cellPx}px)`
+        }}
+      >
+        {candidate.gridData.flatMap((row, rowIndex) =>
+          row.map((cell, columnIndex) => {
+            const tint = cellWordTintAppearance(cellColorMap.get(`${rowIndex},${columnIndex}`));
+            const isEmpty = cell.trim() === '';
+            return (
+              <div
+                key={`${rowIndex}-${columnIndex}`}
+                className={cn(
+                  'flex items-center justify-center overflow-hidden rounded-[2px] leading-none font-medium',
+                  isEmpty ? 'bg-background text-transparent' : 'bg-background text-foreground',
+                  tint.className
+                )}
+                style={{
+                  width: cellPx,
+                  height: cellPx,
+                  fontSize: fontSizePx,
+                  lineHeight: 1,
+                  ...tint.style
+                }}
+              >
+                {cell}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}
+
+function WordChipList({
+  slotIndices,
+  wordList,
+  emptyLabel,
+  tone = 'default'
+}: {
+  slotIndices: readonly number[];
+  wordList: readonly PadavaliWordCandidate[];
+  emptyLabel: string;
+  tone?: 'default' | 'warning';
+}) {
+  if (slotIndices.length === 0) {
+    return <p className="text-xs text-muted-foreground">{emptyLabel}</p>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {slotIndices.map((slotIndex) => {
+        const word = wordList[slotIndex]?.word.trim() || 'Untitled word';
+        const colorPair = getWordColorPair(slotIndex);
+        return (
+          <Badge
+            key={slotIndex}
+            variant="outline"
+            className={cn(
+              'max-w-full gap-1.5 font-normal',
+              tone === 'warning' &&
+                'border-amber-500/40 bg-amber-500/10 text-amber-800 dark:text-amber-200'
+            )}
+          >
+            {tone === 'default' ? (
+              <span
+                aria-hidden
+                className={cn('size-2 shrink-0 rounded-full', wordColorSwatchClassName)}
+                style={wordColorCssVars(colorPair)}
+              />
+            ) : null}
+            <span className="truncate">{word}</span>
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}
+
+function neighborhoodLabel(neighborhood: GeneratedPadavaliLayout['neighborhood']): string {
+  return neighborhood === 'n4' ? 'Up, down, left, and right' : 'Any neighboring cell';
+}
+
+function LayoutCandidateDetail({
+  candidate,
+  wordList,
+  gridDimensions
+}: {
+  candidate: GeneratedPadavaliLayout;
+  wordList: readonly PadavaliWordCandidate[];
+  gridDimensions: [number, number];
+}) {
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+      <GeneratedLayoutPreview
+        candidate={candidate}
+        wordList={wordList}
+        gridDimensions={gridDimensions}
+      />
+      <div className="flex min-w-0 flex-1 flex-col gap-4">
+        <p className="text-xs text-muted-foreground">{neighborhoodLabel(candidate.neighborhood)}</p>
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <h4 className="text-sm font-medium">Placed</h4>
+            <Badge variant="secondary" className="tabular-nums">
+              {candidate.placedSlotIndices.length}
+            </Badge>
+          </div>
+          <WordChipList
+            slotIndices={candidate.placedSlotIndices}
+            wordList={wordList}
+            emptyLabel="No words placed in this layout."
+          />
+        </div>
+        {candidate.omittedSlotIndices.length > 0 ? (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <h4 className="text-sm font-medium text-amber-700 dark:text-amber-300">Excluded</h4>
+              <Badge
+                variant="outline"
+                className="border-amber-500/40 text-amber-700 tabular-nums dark:text-amber-300"
+              >
+                {candidate.omittedSlotIndices.length}
+              </Badge>
+            </div>
+            <WordChipList
+              slotIndices={candidate.omittedSlotIndices}
+              wordList={wordList}
+              emptyLabel="No excluded words."
+              tone="warning"
+            />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function LayoutTabsCarousel({
+  candidates,
+  activeKey,
+  onSelect
+}: {
+  candidates: GeneratedPadavaliLayout[];
+  activeKey: string;
+  onSelect: (key: string) => void;
+}) {
+  const [emblaRef, emblaApi] = useEmblaCarousel({
+    align: 'start',
+    dragFree: true,
+    containScroll: 'trimSnaps',
+    skipSnaps: true,
+    watchDrag: () => true
+  });
+  const activeIndex = candidates.findIndex(
+    (candidate) => layoutCandidateKey(candidate) === activeKey
+  );
+  const canGoPrev = activeIndex > 0;
+  const canGoNext = activeIndex >= 0 && activeIndex < candidates.length - 1;
+
+  useEffect(() => {
+    emblaApi?.reInit();
+  }, [candidates, emblaApi]);
+
+  useEffect(() => {
+    if (!emblaApi || activeIndex < 0) return;
+    emblaApi.scrollTo(activeIndex);
+  }, [activeKey, activeIndex, emblaApi]);
+
+  const goToIndex = (index: number) => {
+    const next = candidates[index];
+    if (!next) return;
+    onSelect(layoutCandidateKey(next));
+    emblaApi?.scrollTo(index);
+  };
+
+  return (
+    <div className="flex shrink-0 flex-col gap-1.5 border-b border-border bg-popover px-3 py-2 sm:px-4">
+      <div className="flex items-center gap-1.5">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          className="shrink-0"
+          disabled={!canGoPrev}
+          aria-label="Previous layout"
+          onClick={() => goToIndex(activeIndex - 1)}
+        >
+          <ChevronLeft />
+        </Button>
+
+        <div
+          ref={emblaRef}
+          className="min-w-0 flex-1 cursor-grab overflow-hidden active:cursor-grabbing"
+          style={{ touchAction: 'pan-y' }}
+        >
+          <TabsList
+            variant="line"
+            className="flex! h-auto w-max max-w-none touch-pan-y justify-start gap-1 select-none"
+          >
+            {candidates.map((candidate, index) => {
+              const key = layoutCandidateKey(candidate);
+              return (
+                <TabsTrigger
+                  key={key}
+                  value={key}
+                  className="flex-none shrink-0 grow-0 basis-auto px-3 select-none"
+                >
+                  Layout {index + 1}
+                  <Badge variant="secondary" className="tabular-nums">
+                    {candidate.score.placedWordCount}
+                  </Badge>
+                </TabsTrigger>
+              );
+            })}
+          </TabsList>
+        </div>
+
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          className="shrink-0"
+          disabled={!canGoNext}
+          aria-label="Next layout"
+          onClick={() => goToIndex(activeIndex + 1)}
+        >
+          <ChevronRight />
+        </Button>
+      </div>
+      <p className="px-0.5 text-[11px] text-muted-foreground/70 select-none">
+        Number = words placed · drag tabs to browse
+      </p>
+    </div>
+  );
+}
+
+export type PadavaliLayoutGeneratorProps = {
+  wordList: readonly PadavaliWordCandidate[];
+  gridDimensions: [number, number];
+  onApply: (layout: GeneratedPadavaliLayout) => void;
+};
+
+export function PadavaliLayoutGenerator({
+  wordList,
+  gridDimensions,
+  onApply
+}: PadavaliLayoutGeneratorProps) {
+  const [open, setOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [ranking, setRanking] = useState<LayoutRanking>('words');
+  const [neighborhood, setNeighborhood] = useState<LayoutNeighborhoodMode>('all');
+  const [pathStyle, setPathStyle] = useState<LayoutPathStyle>('flexible');
+  const [maxCandidates, setMaxCandidates] = useState<LayoutCandidateLimit>(12);
+  const [generationSeed, setGenerationSeed] = useState(1);
+  const [candidates, setCandidates] = useState<GeneratedPadavaliLayout[]>([]);
+  const [selectedKey, setSelectedKey] = useState('');
+  const [candidateToApply, setCandidateToApply] = useState<GeneratedPadavaliLayout | null>(null);
+
+  const rankedCandidates = useMemo(
+    () => rankGeneratedLayouts(candidates, ranking),
+    [candidates, ranking]
+  );
+  const rankedKeys = useMemo(() => rankedCandidates.map(layoutCandidateKey), [rankedCandidates]);
+  const activeKey = rankedKeys.includes(selectedKey) ? selectedKey : (rankedKeys[0] ?? '');
+  const activeCandidate =
+    rankedCandidates.find((candidate) => layoutCandidateKey(candidate) === activeKey) ?? null;
+
+  const runGeneration = ({
+    limit = maxCandidates,
+    rankingOverride = ranking,
+    neighborhoodOverride = neighborhood,
+    pathStyleOverride = pathStyle
+  }: {
+    limit?: LayoutCandidateLimit;
+    rankingOverride?: LayoutRanking;
+    neighborhoodOverride?: LayoutNeighborhoodMode;
+    pathStyleOverride?: LayoutPathStyle;
+  } = {}) => {
+    const usableCount = wordList.filter(
+      (entry) => isWordAdded(entry) && splitDevanagariAksharas(entry.word).length > 0
+    ).length;
+    if (usableCount === 0) {
+      toast.error('Add at least one Devanagari word before generating a layout');
+      return false;
+    }
+    const nextSeed = generationSeed + 1;
+    const nextCandidates = generatePadavaliLayouts({
+      words: wordList,
+      dimensions: gridDimensions,
+      maxCandidates: limit,
+      attempts: Math.max(48, limit * 6),
+      neighborhood: neighborhoodOverride,
+      pathStyle: pathStyleOverride,
+      seed: nextSeed
+    });
+    if (nextCandidates.length === 0) {
+      // Keep prior candidates when a control change finds nothing (e.g. straight runs that cannot fit).
+      setNeighborhood(neighborhoodOverride);
+      setPathStyle(pathStyleOverride);
+      setGenerationSeed(nextSeed);
+      toast.error(
+        'No layout fits these neighbor/word-order settings on the current grid. Try Free to turn, or a larger grid.'
+      );
+      return false;
+    }
+    const ranked = rankGeneratedLayouts(nextCandidates, rankingOverride);
+    setCandidates(nextCandidates);
+    setMaxCandidates(limit);
+    setNeighborhood(neighborhoodOverride);
+    setPathStyle(pathStyleOverride);
+    setGenerationSeed(nextSeed);
+    setSelectedKey(ranked[0] ? layoutCandidateKey(ranked[0]) : '');
+    setCandidateToApply(null);
+    return true;
+  };
+
+  const openGenerator = () => {
+    if (!runGeneration({ rankingOverride: 'words' })) return;
+    setRanking('words');
+    setOpen(true);
+  };
+
+  const applyCandidate = () => {
+    if (!candidateToApply) return;
+    onApply(candidateToApply);
+    setConfirmOpen(false);
+    setOpen(false);
+    toast.success('Generated layout applied');
+  };
+
+  return (
+    <>
+      <Button type="button" variant="outline" size="sm" className="w-fit" onClick={openGenerator}>
+        <WandSparkles data-icon="inline-start" />
+        Generate layouts
+      </Button>
+
+      <Dialog
+        open={open}
+        onOpenChange={(nextOpen) => {
+          setOpen(nextOpen);
+          if (!nextOpen) {
+            setCandidateToApply(null);
+            setSelectedKey('');
+          }
+        }}
+      >
+        <DialogContent className="flex max-h-[min(90vh,52rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
+          <DialogHeader className="shrink-0 gap-1.5 px-4 pt-4 pr-12 pb-3">
+            <DialogTitle>Generate grid layouts</DialogTitle>
+            <DialogDescription>
+              Browse candidates for the current grid size. Choosing one replaces the grid; words
+              that do not fit stay in your list.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="shrink-0 border-b border-border bg-muted/20 px-4 py-3">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="flex min-w-0 flex-col gap-1.5">
+                <div className="flex items-center gap-1">
+                  <Label
+                    htmlFor="padavali-layout-neighborhood"
+                    className="text-xs font-medium tracking-wide text-muted-foreground uppercase"
+                  >
+                    Neighbor moves
+                  </Label>
+                  <Popover>
+                    <PopoverTrigger
+                      render={<Info className="size-3.5 text-muted-foreground" />}
+                      nativeButton={false}
+                      aria-label="About neighbor moves"
+                    />
+                    <PopoverContent className="max-w-xs text-xs leading-snug" align="start">
+                      {NEIGHBOR_MOVES_INFO}
+                    </PopoverContent>
+                  </Popover>
+                </div>
+                <Select
+                  items={[...LAYOUT_NEIGHBORHOOD_ITEMS]}
+                  value={neighborhood}
+                  onValueChange={(value) => {
+                    const nextNeighborhood = parseLayoutNeighborhood(value);
+                    if (!nextNeighborhood || nextNeighborhood === neighborhood) return;
+                    runGeneration({ neighborhoodOverride: nextNeighborhood });
+                  }}
+                >
+                  <SelectTrigger id="padavali-layout-neighborhood" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {LAYOUT_NEIGHBORHOOD_ITEMS.map((item) => (
+                      <SelectItem key={item.value} value={item.value}>
+                        {item.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="flex min-w-0 flex-col gap-1.5">
+                <div className="flex items-center gap-1">
+                  <Label
+                    htmlFor="padavali-layout-path-style"
+                    className="text-xs font-medium tracking-wide text-muted-foreground uppercase"
+                  >
+                    Word order
+                  </Label>
+                  <Popover>
+                    <PopoverTrigger
+                      render={<Info className="size-3.5 text-muted-foreground" />}
+                      nativeButton={false}
+                      aria-label="About word order"
+                    />
+                    <PopoverContent className="max-w-xs text-xs leading-snug" align="start">
+                      {WORD_ORDER_INFO}
+                    </PopoverContent>
+                  </Popover>
+                </div>
+                <Select
+                  items={[...LAYOUT_PATH_STYLE_ITEMS]}
+                  value={pathStyle}
+                  onValueChange={(value) => {
+                    const nextStyle = parseLayoutPathStyle(value);
+                    if (!nextStyle || nextStyle === pathStyle) return;
+                    runGeneration({ pathStyleOverride: nextStyle });
+                  }}
+                >
+                  <SelectTrigger id="padavali-layout-path-style" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {LAYOUT_PATH_STYLE_ITEMS.map((item) => (
+                      <SelectItem key={item.value} value={item.value}>
+                        {item.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="flex min-w-0 flex-col gap-1.5">
+                <Label
+                  htmlFor="padavali-layout-ranking"
+                  className="text-xs font-medium tracking-wide text-muted-foreground uppercase"
+                >
+                  Rank by
+                </Label>
+                <Select
+                  items={[...LAYOUT_RANKING_ITEMS]}
+                  value={ranking}
+                  onValueChange={(value) => {
+                    const nextRanking = parseLayoutRanking(value);
+                    if (nextRanking) setRanking(nextRanking);
+                  }}
+                >
+                  <SelectTrigger id="padavali-layout-ranking" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {LAYOUT_RANKING_ITEMS.map((item) => (
+                      <SelectItem key={item.value} value={item.value}>
+                        {item.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-[11px] leading-snug text-muted-foreground/80">
+                  Reorders tabs without regenerating
+                </p>
+              </div>
+
+              <div className="flex min-w-0 flex-col gap-1.5">
+                <Label
+                  htmlFor="padavali-layout-candidate-limit"
+                  className="text-xs font-medium tracking-wide text-muted-foreground uppercase"
+                >
+                  Candidates
+                </Label>
+                <Select
+                  items={[...LAYOUT_CANDIDATE_LIMIT_ITEMS]}
+                  value={String(maxCandidates)}
+                  onValueChange={(value) => {
+                    const nextLimit = parseLayoutCandidateLimit(value);
+                    if (!nextLimit || nextLimit === maxCandidates) return;
+                    runGeneration({ limit: nextLimit });
+                  }}
+                >
+                  <SelectTrigger id="padavali-layout-candidate-limit" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {LAYOUT_CANDIDATE_LIMIT_ITEMS.map((item) => (
+                      <SelectItem key={item.value} value={item.value}>
+                        {item.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-[11px] leading-snug text-muted-foreground/80">
+                  Max distinct layouts to keep
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {rankedCandidates.length > 0 && activeKey ? (
+            <Tabs
+              value={activeKey}
+              onValueChange={setSelectedKey}
+              className="flex min-h-0 flex-1 flex-col gap-0 overflow-hidden"
+            >
+              <LayoutTabsCarousel
+                candidates={rankedCandidates}
+                activeKey={activeKey}
+                onSelect={setSelectedKey}
+              />
+
+              <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-4 pt-4 pb-6">
+                {rankedCandidates.map((candidate) => {
+                  const key = layoutCandidateKey(candidate);
+                  return (
+                    <TabsContent key={key} value={key} className="mt-0 outline-none">
+                      <LayoutCandidateDetail
+                        candidate={candidate}
+                        wordList={wordList}
+                        gridDimensions={gridDimensions}
+                      />
+                    </TabsContent>
+                  );
+                })}
+              </div>
+            </Tabs>
+          ) : null}
+
+          <DialogFooter className="shrink-0 border-t border-border px-4 py-3">
+            <div className="flex w-full flex-wrap justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  runGeneration();
+                }}
+              >
+                Generate again
+              </Button>
+              <Button variant="outline" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                disabled={!activeCandidate}
+                onClick={() => {
+                  if (!activeCandidate) return;
+                  setCandidateToApply(activeCandidate);
+                  setConfirmOpen(true);
+                }}
+              >
+                Use this layout
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Replace the current grid?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This replaces the current grid letters. Words that do not fit will be excluded, while
+              remaining in the word list. You can undo this as one change.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep current grid</AlertDialogCancel>
+            <AlertDialogAction onClick={applyCandidate}>Use generated layout</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/pages/padavali/PadavaliLayoutGenerator.tsx
+++ b/src/components/pages/padavali/PadavaliLayoutGenerator.tsx
@@ -72,8 +72,7 @@ const WORD_ORDER_INFO =
 
 const LAYOUT_RANKING_ITEMS = [
   { value: 'words', label: 'Most words' },
-  { value: 'fill', label: 'Fewest empty cells' },
-  { value: 'compact', label: 'Most compact' }
+  { value: 'fill', label: 'Fewest empty cells' }
 ] as const;
 
 const LAYOUT_CANDIDATE_LIMITS = [4, 8, 12, 16, 24, 32] as const;
@@ -95,7 +94,7 @@ function parseLayoutPathStyle(value: string | null | undefined): LayoutPathStyle
 }
 
 function parseLayoutRanking(value: string | null | undefined): LayoutRanking | null {
-  if (value === 'words' || value === 'fill' || value === 'compact') return value;
+  if (value === 'words' || value === 'fill') return value;
   return null;
 }
 
@@ -132,6 +131,21 @@ function GeneratedLayoutPreview({
   const gridWidth = cellPx * cols + LAYOUT_PREVIEW_GAP_PX * Math.max(0, cols - 1);
   const gridHeight = cellPx * rows + LAYOUT_PREVIEW_GAP_PX * Math.max(0, rows - 1);
   const fontSizePx = Math.max(8, Math.min(14, cellPx - 6));
+  const trailGlowWidth = Math.max(2, Math.min(4.5, cellPx * 0.22));
+  const trailMainWidth = Math.max(1, Math.min(2, cellPx * 0.1));
+
+  const cellCenter = (row: number, col: number) => ({
+    x: col * (cellPx + LAYOUT_PREVIEW_GAP_PX) + cellPx / 2,
+    y: row * (cellPx + LAYOUT_PREVIEW_GAP_PX) + cellPx / 2
+  });
+
+  const buildPoints = (path: readonly (readonly [number, number])[]) =>
+    path
+      .map(([row, col]) => {
+        const { x, y } = cellCenter(row, col);
+        return `${x},${y}`;
+      })
+      .join(' ');
 
   return (
     <div
@@ -140,40 +154,102 @@ function GeneratedLayoutPreview({
     >
       <div
         aria-label={`Generated ${rows} by ${cols} grid preview`}
-        className="grid bg-border/60"
-        style={{
-          width: gridWidth,
-          height: gridHeight,
-          gap: LAYOUT_PREVIEW_GAP_PX,
-          gridTemplateColumns: `repeat(${cols}, ${cellPx}px)`,
-          gridTemplateRows: `repeat(${rows}, ${cellPx}px)`
-        }}
+        className="relative"
+        style={{ width: gridWidth, height: gridHeight }}
       >
-        {candidate.gridData.flatMap((row, rowIndex) =>
-          row.map((cell, columnIndex) => {
-            const tint = cellWordTintAppearance(cellColorMap.get(`${rowIndex},${columnIndex}`));
-            const isEmpty = cell.trim() === '';
+        <div
+          className="relative z-10 grid bg-border/60"
+          style={{
+            width: gridWidth,
+            height: gridHeight,
+            gap: LAYOUT_PREVIEW_GAP_PX,
+            gridTemplateColumns: `repeat(${cols}, ${cellPx}px)`,
+            gridTemplateRows: `repeat(${rows}, ${cellPx}px)`
+          }}
+        >
+          {candidate.gridData.flatMap((row, rowIndex) =>
+            row.map((cell, columnIndex) => {
+              const tint = cellWordTintAppearance(cellColorMap.get(`${rowIndex},${columnIndex}`));
+              const isEmpty = cell.trim() === '';
+              return (
+                <div
+                  key={`${rowIndex}-${columnIndex}`}
+                  className={cn(
+                    'relative z-10 flex items-center justify-center overflow-hidden rounded-[2px] leading-none font-medium',
+                    isEmpty ? 'bg-background text-transparent' : 'bg-background text-foreground',
+                    tint.className
+                  )}
+                  style={{
+                    width: cellPx,
+                    height: cellPx,
+                    fontSize: fontSizePx,
+                    lineHeight: 1,
+                    ...tint.style
+                  }}
+                >
+                  {cell}
+                </div>
+              );
+            })
+          )}
+        </div>
+        {/* Soft path overlay — readable glyphs, still clear path order */}
+        <svg
+          className="pointer-events-none absolute inset-0 z-20 overflow-visible"
+          width={gridWidth}
+          height={gridHeight}
+          aria-hidden
+        >
+          {candidate.placements.map(({ slotIndex, path }) => {
+            if (path.length < 2) return null;
+            const points = buildPoints(path);
+            const pair = getWordColorPair(slotIndex);
             return (
-              <div
-                key={`${rowIndex}-${columnIndex}`}
-                className={cn(
-                  'flex items-center justify-center overflow-hidden rounded-[2px] leading-none font-medium',
-                  isEmpty ? 'bg-background text-transparent' : 'bg-background text-foreground',
-                  tint.className
-                )}
-                style={{
-                  width: cellPx,
-                  height: cellPx,
-                  fontSize: fontSizePx,
-                  lineHeight: 1,
-                  ...tint.style
-                }}
-              >
-                {cell}
-              </div>
+              <g key={`preview-trail-${slotIndex}-${path.map(([r, c]) => `${r},${c}`).join('|')}`}>
+                <polyline
+                  points={points}
+                  fill="none"
+                  stroke={pair.light.swatch}
+                  strokeWidth={trailGlowWidth}
+                  strokeOpacity={0.08}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="dark:hidden"
+                />
+                <polyline
+                  points={points}
+                  fill="none"
+                  stroke={pair.light.swatch}
+                  strokeWidth={trailMainWidth}
+                  strokeOpacity={0.26}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="dark:hidden"
+                />
+                <polyline
+                  points={points}
+                  fill="none"
+                  stroke={pair.dark.swatch}
+                  strokeWidth={trailGlowWidth}
+                  strokeOpacity={0.1}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="hidden dark:block"
+                />
+                <polyline
+                  points={points}
+                  fill="none"
+                  stroke={pair.dark.swatch}
+                  strokeWidth={trailMainWidth}
+                  strokeOpacity={0.28}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="hidden dark:block"
+                />
+              </g>
             );
-          })
-        )}
+          })}
+        </svg>
       </div>
     </div>
   );

--- a/src/components/pages/padavali/PadavaliLayoutGenerator.tsx
+++ b/src/components/pages/padavali/PadavaliLayoutGenerator.tsx
@@ -495,11 +495,26 @@ export function PadavaliLayoutGenerator({
       >
         <DialogContent className="flex max-h-[min(90vh,52rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl">
           <DialogHeader className="shrink-0 gap-1.5 px-4 pt-4 pr-12 pb-3">
-            <DialogTitle>Generate grid layouts</DialogTitle>
-            <DialogDescription>
-              Browse candidates for the current grid size. Choosing one replaces the grid; words
-              that do not fit stay in your list.
-            </DialogDescription>
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex min-w-0 flex-col gap-1.5">
+                <DialogTitle>Generate grid layouts</DialogTitle>
+                <DialogDescription>
+                  Browse candidates for the current grid size. Choosing one replaces the grid; words
+                  that do not fit stay in your list.
+                </DialogDescription>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="shrink-0"
+                onClick={() => {
+                  runGeneration();
+                }}
+              >
+                Generate again
+              </Button>
+            </div>
           </DialogHeader>
 
           <div className="shrink-0 border-b border-border bg-muted/20 px-4 py-3">
@@ -682,15 +697,6 @@ export function PadavaliLayoutGenerator({
 
           <DialogFooter className="shrink-0 border-t border-border px-4 py-3">
             <div className="flex w-full flex-wrap justify-end gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => {
-                  runGeneration();
-                }}
-              >
-                Generate again
-              </Button>
               <Button variant="outline" onClick={() => setOpen(false)}>
                 Cancel
               </Button>

--- a/src/components/pages/padavali/PadavaliWordListEditor.tsx
+++ b/src/components/pages/padavali/PadavaliWordListEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, type ReactNode } from 'react';
 import { IoMdAdd, IoMdClose } from 'react-icons/io';
 import {
   clearTypingContextOnKeyDown,
@@ -212,6 +212,7 @@ export type PadavaliWordListEditorProps = {
   onRemoveWord: (index: number) => void;
   onUpdateWord: (index: number, value: string) => void;
   onToggleAdded: (index: number, added: boolean) => void;
+  addedWordsActions?: ReactNode;
 };
 
 export function PadavaliWordListEditor({
@@ -221,7 +222,8 @@ export function PadavaliWordListEditor({
   onAddWord,
   onRemoveWord,
   onUpdateWord,
-  onToggleAdded
+  onToggleAdded,
+  addedWordsActions
 }: PadavaliWordListEditorProps) {
   const typingContext = useMemo(() => createTypingContext(BASE_SCRIPT), []);
   const fullCandidates = wordList.map((entry, originalIndex) => ({ entry, originalIndex }));
@@ -258,10 +260,19 @@ export function PadavaliWordListEditor({
               onUpdateWord={onUpdateWord}
               onToggleAdded={onToggleAdded}
             />
-            <Button type="button" variant="outline" size="sm" className="w-fit" onClick={onAddWord}>
-              <IoMdAdd data-icon="inline-start" />
-              Add Word Slot
-            </Button>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="w-fit"
+                onClick={onAddWord}
+              >
+                <IoMdAdd data-icon="inline-start" />
+                Add Word Slot
+              </Button>
+              {addedWordsActions}
+            </div>
           </div>
         </TabsContent>
         <TabsContent value="edit">

--- a/src/components/pages/padavali/ViewEditPuzzle.tsx
+++ b/src/components/pages/padavali/ViewEditPuzzle.tsx
@@ -92,13 +92,11 @@ import {
 } from '~/hooks/useEditorHistory';
 import { padavaliActiveWords } from '~/util/puzzle/word_list';
 import { PadavaliWordListEditor } from '~/components/pages/padavali/PadavaliWordListEditor';
+import { PadavaliLayoutGenerator } from '~/components/pages/padavali/PadavaliLayoutGenerator';
 import {
   buildCellWordColorMap,
+  cellWordTintAppearance,
   getActiveNonEmptyWordSlotIndices,
-  getWordColorPair,
-  WORD_COLOR_CONFLICT,
-  wordColorCssVars,
-  wordColorTintClassName,
   type CellWordColorInfo
 } from '~/util/puzzle/word_colors';
 
@@ -569,10 +567,13 @@ const TraversalAndGridData = ({ grid_dimensions }: { grid_dimensions: [number, n
     grid_dimensions
   );
 
+  const uniqueTraversalsMap = new Map(
+    [...traversalsMap.entries()].filter(([, traversals]) => traversals.length === 1)
+  );
   const cellColorMap =
     gridData.length === 0 || wordList.length === 0
       ? new Map<string, CellWordColorInfo>()
-      : buildCellWordColorMap(traversalsMap, getActiveNonEmptyWordSlotIndices(wordList));
+      : buildCellWordColorMap(uniqueTraversalsMap, getActiveNonEmptyWordSlotIndices(wordList));
 
   return (
     <>
@@ -926,6 +927,7 @@ const TraversalAnalysis = ({
 
 const WordList = ({ gridDimensions }: { gridDimensions: [number, number] }) => {
   const [wordList, setWordList] = useAtom(word_list_atom);
+  const [, setGridData] = useAtom(grid_data_atom);
   const [lipi_lekhika_active] = useAtom(lipi_lekhika_active_atom);
   const { commit } = useEditorHistoryActions();
 
@@ -954,6 +956,24 @@ const WordList = ({ gridDimensions }: { gridDimensions: [number, number] }) => {
       onRemoveWord={removeWord}
       onUpdateWord={updateWord}
       onToggleAdded={toggleAdded}
+      addedWordsActions={
+        <PadavaliLayoutGenerator
+          wordList={wordList}
+          gridDimensions={gridDimensions}
+          onApply={(layout) => {
+            setGridData(layout.gridData);
+            if (layout.omittedSlotIndices.length > 0) {
+              const omitted = new Set(layout.omittedSlotIndices);
+              setWordList((prev) =>
+                prev.map((entry, index) =>
+                  omitted.has(index) ? { ...entry, added: false } : entry
+                )
+              );
+            }
+            commit();
+          }}
+        />
+      }
     />
   );
 };
@@ -1017,24 +1037,18 @@ const GridData = ({
   };
 
   const getCellAppearance = (r: number, c: number) => {
-    const info = cellColorMap.get(`${r},${c}`);
-    const focusClassName = cn(
-      'rounded text-center transition-colors duration-200',
-      // Distinct focus highlighter — stays readable over soft word tints
-      'focus-visible:z-10 focus-visible:border-foreground/50',
-      'focus-visible:ring-2 focus-visible:ring-foreground/55 focus-visible:ring-offset-2',
-      'focus-visible:ring-offset-background',
-      'dark:focus-visible:border-white/70 dark:focus-visible:ring-white/65'
-    );
-
-    if (!info) {
-      return { className: focusClassName, style: undefined };
-    }
-
-    const pair = info.conflict ? WORD_COLOR_CONFLICT : getWordColorPair(info.slotIndex);
+    const tint = cellWordTintAppearance(cellColorMap.get(`${r},${c}`));
     return {
-      className: cn(focusClassName, wordColorTintClassName),
-      style: wordColorCssVars(pair)
+      className: cn(
+        'rounded text-center transition-colors duration-200',
+        // Distinct focus highlighter — stays readable over soft word tints
+        'focus-visible:z-10 focus-visible:border-foreground/50',
+        'focus-visible:ring-2 focus-visible:ring-foreground/55 focus-visible:ring-offset-2',
+        'focus-visible:ring-offset-background',
+        'dark:focus-visible:border-white/70 dark:focus-visible:ring-white/65',
+        tint.className
+      ),
+      style: tint.style
     };
   };
 

--- a/src/components/pages/padavali/ViewEditPuzzle.tsx
+++ b/src/components/pages/padavali/ViewEditPuzzle.tsx
@@ -97,6 +97,7 @@ import {
   buildCellWordColorMap,
   cellWordTintAppearance,
   getActiveNonEmptyWordSlotIndices,
+  getWordColorPair,
   type CellWordColorInfo
 } from '~/util/puzzle/word_colors';
 
@@ -557,6 +558,26 @@ const getCellConflicts = (
   return conflicts;
 };
 
+type WordTrail = {
+  slotIndex: number;
+  path: Coordinate[];
+};
+
+/** Unique single-path placements only — same source as cell tints. */
+function getUniqueWordTrails(
+  uniqueTraversalsMap: Map<number, Traversal[]>,
+  slotIndices: readonly number[]
+): WordTrail[] {
+  const trails: WordTrail[] = [];
+  for (const [validIdx, traversals] of uniqueTraversalsMap) {
+    const path = traversals[0];
+    const slotIndex = slotIndices[validIdx];
+    if (!path || path.length < 2 || slotIndex === undefined) continue;
+    trails.push({ slotIndex, path: path.map(([r, c]) => [r, c] as Coordinate) });
+  }
+  return trails;
+}
+
 const TraversalAndGridData = ({ grid_dimensions }: { grid_dimensions: [number, number] }) => {
   const [wordList] = useAtom(word_list_atom);
   const [gridData] = useAtom(grid_data_atom);
@@ -567,13 +588,18 @@ const TraversalAndGridData = ({ grid_dimensions }: { grid_dimensions: [number, n
     grid_dimensions
   );
 
+  const slotIndices = getActiveNonEmptyWordSlotIndices(wordList);
   const uniqueTraversalsMap = new Map(
     [...traversalsMap.entries()].filter(([, traversals]) => traversals.length === 1)
   );
   const cellColorMap =
     gridData.length === 0 || wordList.length === 0
       ? new Map<string, CellWordColorInfo>()
-      : buildCellWordColorMap(uniqueTraversalsMap, getActiveNonEmptyWordSlotIndices(wordList));
+      : buildCellWordColorMap(uniqueTraversalsMap, slotIndices);
+  const wordTrails =
+    gridData.length === 0 || wordList.length === 0
+      ? []
+      : getUniqueWordTrails(uniqueTraversalsMap, slotIndices);
 
   return (
     <>
@@ -583,7 +609,11 @@ const TraversalAndGridData = ({ grid_dimensions }: { grid_dimensions: [number, n
         validWords={validWords}
         occupiedCells={occupiedCells}
       />
-      <GridData grid_dimensions={grid_dimensions} cellColorMap={cellColorMap} />
+      <GridData
+        grid_dimensions={grid_dimensions}
+        cellColorMap={cellColorMap}
+        wordTrails={wordTrails}
+      />
     </>
   );
 };
@@ -980,16 +1010,87 @@ const WordList = ({ gridDimensions }: { gridDimensions: [number, number] }) => {
 
 const GridData = ({
   grid_dimensions,
-  cellColorMap
+  cellColorMap,
+  wordTrails
 }: {
   grid_dimensions: [number, number];
   cellColorMap: Map<string, CellWordColorInfo>;
+  wordTrails: WordTrail[];
 }) => {
   const [gridData, setGridData] = useAtom(grid_data_atom);
   const [rows, cols] = grid_dimensions;
   const [lipi_lekhika_active] = useAtom(lipi_lekhika_active_atom);
   const historyField = useHistoryTextField();
   const gridRef = useRef<HTMLDivElement>(null);
+  const [cellCenters, setCellCenters] = useState<Record<string, { x: number; y: number }>>({});
+  const lastGridSizeRef = useRef({ width: 0, height: 0 });
+
+  // Measure cell centers for SVG connector trails (same approach as GameGrid / landing demo)
+  useEffect(() => {
+    const el = gridRef.current;
+    if (!el) return;
+
+    let rafId: number | null = null;
+
+    const syncLayout = () => {
+      const parentRect = el.getBoundingClientRect();
+      const rounded = {
+        width: Math.round(parentRect.width),
+        height: Math.round(parentRect.height)
+      };
+      if (rounded.width === 0 || rounded.height === 0) return;
+
+      const centers: Record<string, { x: number; y: number }> = {};
+      const cells = el.querySelectorAll<HTMLElement>('input[data-grid-r][data-grid-c]');
+      for (const cell of cells) {
+        const r = cell.dataset.gridR;
+        const c = cell.dataset.gridC;
+        if (r === undefined || c === undefined) continue;
+        const cellRect = cell.getBoundingClientRect();
+        centers[`${r}-${c}`] = {
+          x: cellRect.left + cellRect.width / 2 - parentRect.left,
+          y: cellRect.top + cellRect.height / 2 - parentRect.top
+        };
+      }
+
+      const sizeChanged =
+        rounded.width !== lastGridSizeRef.current.width ||
+        rounded.height !== lastGridSizeRef.current.height;
+      lastGridSizeRef.current = rounded;
+      // Always refresh when trails/grid content change; size gate only skips identical resize noise
+      if (sizeChanged || Object.keys(centers).length > 0) {
+        setCellCenters(centers);
+      }
+    };
+
+    const scheduleSync = () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        syncLayout();
+      });
+    };
+
+    syncLayout();
+    const observer = new ResizeObserver(scheduleSync);
+    observer.observe(el);
+    window.addEventListener('resize', scheduleSync, { passive: true });
+
+    return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      observer.disconnect();
+      window.removeEventListener('resize', scheduleSync);
+    };
+  }, [gridData, rows, cols]);
+
+  const buildPoints = (path: Coordinate[]) =>
+    path
+      .map(([r, c]) => {
+        const center = cellCenters[`${r}-${c}`];
+        return center ? `${center.x},${center.y}` : null;
+      })
+      .filter((p): p is string => p !== null)
+      .join(' ');
 
   const updateCell = (r: number, c: number, value: string) => {
     setGridData((prev) => {
@@ -1040,9 +1141,9 @@ const GridData = ({
     const tint = cellWordTintAppearance(cellColorMap.get(`${r},${c}`));
     return {
       className: cn(
-        'rounded text-center transition-colors duration-200',
-        // Distinct focus highlighter — stays readable over soft word tints
-        'focus-visible:z-10 focus-visible:border-foreground/50',
+        'relative z-10 rounded text-center transition-colors duration-200',
+        // Focus above soft trail overlay
+        'focus-visible:z-30 focus-visible:border-foreground/50',
         'focus-visible:ring-2 focus-visible:ring-foreground/55 focus-visible:ring-offset-2',
         'focus-visible:ring-offset-background',
         'dark:focus-visible:border-white/70 dark:focus-visible:ring-white/65',
@@ -1056,45 +1157,101 @@ const GridData = ({
     <div>
       <Label className="mb-2 block text-lg font-semibold">Grid</Label>
       <p className="mb-2 hidden text-xs text-muted-foreground/80 sm:block">
-        Navigate the grid with the arrow keys (↑ ↓ ← →)
+        Navigate the grid with the arrow keys (↑ ↓ ← →). Colored trails show each word’s path order.
       </p>
-      <div
-        ref={gridRef}
-        className="md:3/5 grid w-full gap-1 sm:w-4/5 md:w-3/5 lg:w-2/5"
-        style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
-      >
-        {gridData.map((row, r) =>
-          row.map((cell, c) => {
-            const { className, style } = getCellAppearance(r, c);
+      <div ref={gridRef} className="relative w-full sm:w-4/5 md:w-3/5 lg:w-2/5">
+        <div
+          className="relative z-10 grid w-full gap-1"
+          style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+        >
+          {gridData.map((row, r) =>
+            row.map((cell, c) => {
+              const { className, style } = getCellAppearance(r, c);
+              return (
+                <Input
+                  key={`${r}-${c}`}
+                  type="text"
+                  data-grid-r={r}
+                  data-grid-c={c}
+                  className={className}
+                  style={style}
+                  minLength={1}
+                  value={cell}
+                  onChange={(e) => updateCell(r, c, e.currentTarget.value)}
+                  onBeforeInput={(e) =>
+                    handleTypingBeforeInputEvent(
+                      ctx,
+                      e,
+                      (newValue) => updateCell(r, c, newValue),
+                      lipi_lekhika_active
+                    )
+                  }
+                  onFocus={historyField.onFocus}
+                  onBlur={() => {
+                    ctx.clearContext();
+                    historyField.onBlur();
+                  }}
+                  onKeyDown={(e) => handleCellKeyDown(r, c, e)}
+                />
+              );
+            })
+          )}
+        </div>
+        {/* Soft path overlay — above cells but light enough to keep glyphs readable */}
+        <svg
+          className="pointer-events-none absolute inset-0 z-20 h-full w-full overflow-visible"
+          aria-hidden
+        >
+          {wordTrails.map(({ slotIndex, path }) => {
+            const points = buildPoints(path);
+            if (!points || points.split(' ').length < 2) return null;
+            const pair = getWordColorPair(slotIndex);
             return (
-              <Input
-                key={`${r}-${c}`}
-                type="text"
-                data-grid-r={r}
-                data-grid-c={c}
-                className={className}
-                style={style}
-                minLength={1}
-                value={cell}
-                onChange={(e) => updateCell(r, c, e.currentTarget.value)}
-                onBeforeInput={(e) =>
-                  handleTypingBeforeInputEvent(
-                    ctx,
-                    e,
-                    (newValue) => updateCell(r, c, newValue),
-                    lipi_lekhika_active
-                  )
-                }
-                onFocus={historyField.onFocus}
-                onBlur={() => {
-                  ctx.clearContext();
-                  historyField.onBlur();
-                }}
-                onKeyDown={(e) => handleCellKeyDown(r, c, e)}
-              />
+              <g key={`trail-${slotIndex}-${path.map(([r, c]) => `${r},${c}`).join('|')}`}>
+                <polyline
+                  points={points}
+                  fill="none"
+                  stroke={pair.light.swatch}
+                  strokeWidth={4.5}
+                  strokeOpacity={0.08}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="dark:hidden"
+                />
+                <polyline
+                  points={points}
+                  fill="none"
+                  stroke={pair.light.swatch}
+                  strokeWidth={1.75}
+                  strokeOpacity={0.26}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="dark:hidden"
+                />
+                <polyline
+                  points={points}
+                  fill="none"
+                  stroke={pair.dark.swatch}
+                  strokeWidth={5}
+                  strokeOpacity={0.1}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="hidden dark:block"
+                />
+                <polyline
+                  points={points}
+                  fill="none"
+                  stroke={pair.dark.swatch}
+                  strokeWidth={2}
+                  strokeOpacity={0.28}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="hidden dark:block"
+                />
+              </g>
             );
-          })
-        )}
+          })}
+        </svg>
       </div>
     </div>
   );

--- a/src/tools/puzzle/puzzle_tools.ts
+++ b/src/tools/puzzle/puzzle_tools.ts
@@ -1,29 +1,47 @@
 export type Coordinate = [number, number];
 export type Traversal = Coordinate[];
 
+/** Orthogonal neighbors (up, down, left, right). */
+export type GridNeighborhood = 'n4' | 'n8';
+
+export const GRID_DIRECTIONS_N4: readonly Coordinate[] = [
+  [-1, 0],
+  [1, 0],
+  [0, -1],
+  [0, 1]
+];
+
+/** All adjacent neighbors, including diagonals — how players swipe in the game. */
+export const GRID_DIRECTIONS_N8: readonly Coordinate[] = [
+  [-1, -1],
+  [-1, 0],
+  [-1, 1],
+  [0, -1],
+  [0, 1],
+  [1, -1],
+  [1, 0],
+  [1, 1]
+];
+
+export function neighborhoodDirections(neighborhood: GridNeighborhood): readonly Coordinate[] {
+  return neighborhood === 'n4' ? GRID_DIRECTIONS_N4 : GRID_DIRECTIONS_N8;
+}
+
 /**
  * Finds all possible ways to traverse the grid to form each word in the list.
  * Returns a map from word index to an array of traversals (each traversal is an array of coordinates).
+ *
+ * Defaults to 8-neighbor moves so results match live play (diagonal swipes allowed).
  */
 export function findAllTraversals(
   gridData: string[][],
   gridDimensions: [number, number],
-  wordList: string[]
+  wordList: string[],
+  neighborhood: GridNeighborhood = 'n8'
 ): Map<number, Traversal[]> {
   const [rows, cols] = gridDimensions;
   const result = new Map<number, Traversal[]>();
-
-  // All 8 directions
-  const directions: Coordinate[] = [
-    [-1, -1],
-    [-1, 0],
-    [-1, 1],
-    [0, -1],
-    [0, 1],
-    [1, -1],
-    [1, 0],
-    [1, 1]
-  ];
+  const directions = neighborhoodDirections(neighborhood);
 
   for (let wIdx = 0; wIdx < wordList.length; wIdx++) {
     const word = wordList[wIdx];

--- a/src/util/puzzle/devanagari_syllables.test.ts
+++ b/src/util/puzzle/devanagari_syllables.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { countDevanagariAksharas } from './devanagari_syllables';
+import { countDevanagariAksharas, splitDevanagariAksharas } from './devanagari_syllables';
 
 describe('countDevanagariAksharas', () => {
   it.each([
@@ -36,5 +36,12 @@ describe('countDevanagariAksharas', () => {
     ['ॷ', 1]
   ])('counts %s as %i akṣaras', (word, expected) => {
     expect(countDevanagariAksharas(word)).toBe(expected);
+    expect(splitDevanagariAksharas(word)).toHaveLength(expected);
+  });
+
+  it('splits conjuncts into the same units used for counting', () => {
+    expect(splitDevanagariAksharas('गङ्गा')).toEqual(['ग', 'ङ्गा']);
+    expect(splitDevanagariAksharas('शक्तिः')).toEqual(['श', 'क्तिः']);
+    expect(splitDevanagariAksharas('राम')).toEqual(['रा', 'म']);
   });
 });

--- a/src/util/puzzle/devanagari_syllables.ts
+++ b/src/util/puzzle/devanagari_syllables.ts
@@ -62,14 +62,14 @@ function consumeAkshara(characters: readonly string[], start: number): number {
 }
 
 /**
- * Returns the number of Devanagari akṣaras in `text`.
+ * Splits `text` into Devanagari akṣaras (one grid cell each).
  *
  * Whitespace, punctuation, non-Devanagari characters, and unattached combining
- * marks are ignored so unfinished editor input never produces a phantom count.
+ * marks are ignored so unfinished editor input never produces a phantom unit.
  */
-export function countDevanagariAksharas(text: string): number {
+export function splitDevanagariAksharas(text: string): string[] {
   const characters = Array.from(text.normalize('NFC'));
-  let count = 0;
+  const syllables: string[] = [];
 
   for (let index = 0; index < characters.length;) {
     const character = characters[index]!;
@@ -78,9 +78,20 @@ export function countDevanagariAksharas(text: string): number {
       continue;
     }
 
-    count += 1;
-    index = consumeAkshara(characters, index);
+    const end = consumeAkshara(characters, index);
+    syllables.push(characters.slice(index, end).join(''));
+    index = end;
   }
 
-  return count;
+  return syllables;
+}
+
+/**
+ * Returns the number of Devanagari akṣaras in `text`.
+ *
+ * Whitespace, punctuation, non-Devanagari characters, and unattached combining
+ * marks are ignored so unfinished editor input never produces a phantom count.
+ */
+export function countDevanagariAksharas(text: string): number {
+  return splitDevanagariAksharas(text).length;
 }

--- a/src/util/puzzle/layout_generator.test.ts
+++ b/src/util/puzzle/layout_generator.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+import { findAllTraversals } from '~/tools/puzzle/puzzle_tools';
+import { SAMPLE_DATA } from '~/tools/puzzle/sample_puzzle_data';
+import {
+  generatePadavaliLayouts,
+  rankGeneratedLayouts,
+  type GeneratedPadavaliLayout
+} from './layout_generator';
+import { buildCellWordColorMap, getActiveNonEmptyWordSlotIndices } from './word_colors';
+
+const smallWords = [
+  { word: 'राम', added: true },
+  { word: 'नल', added: true },
+  { word: 'यमुना', added: true }
+];
+
+function placedWords(candidate: GeneratedPadavaliLayout, source: typeof smallWords) {
+  return candidate.placedSlotIndices.map((slotIndex) => source[slotIndex]!.word);
+}
+
+function pathStepsAreOrthogonal(candidate: GeneratedPadavaliLayout): boolean {
+  return candidate.placements.every((placement) =>
+    placement.path.every((cell, index) => {
+      if (index === 0) return true;
+      const previous = placement.path[index - 1]!;
+      const dRow = Math.abs(cell[0] - previous[0]);
+      const dCol = Math.abs(cell[1] - previous[1]);
+      return dRow + dCol === 1;
+    })
+  );
+}
+
+function pathIsStraightAcrossOrDown(candidate: GeneratedPadavaliLayout): boolean {
+  return candidate.placements.every((placement) => {
+    if (placement.path.length <= 1) return true;
+    const [startRow, startCol] = placement.path[0]!;
+    const end = placement.path[placement.path.length - 1]!;
+    const sameRow = placement.path.every(([row]) => row === startRow);
+    const sameCol = placement.path.every(([, col]) => col === startCol);
+    if (sameRow) {
+      return placement.path.every((cell, index) => cell[1] === startCol + index);
+    }
+    if (sameCol) {
+      return placement.path.every((cell, index) => cell[0] === startRow + index);
+    }
+    return false;
+  });
+}
+
+describe('padavali layout generator', () => {
+  it('produces unique-path layouts that fill distinct cells', () => {
+    const candidates = generatePadavaliLayouts({
+      words: smallWords,
+      dimensions: [3, 3],
+      seed: 11,
+      attempts: 24,
+      maxCandidates: 8
+    });
+
+    expect(candidates.length).toBeGreaterThan(0);
+    for (const candidate of candidates) {
+      expect(candidate.gridData).toHaveLength(3);
+      expect(candidate.gridData.every((row) => row.length === 3)).toBe(true);
+      expect(candidate.score.placedWordCount).toBeGreaterThan(0);
+      const words = placedWords(candidate, smallWords);
+      const traversalsMap = findAllTraversals(
+        candidate.gridData,
+        [3, 3],
+        words,
+        candidate.neighborhood
+      );
+      for (let index = 0; index < words.length; index += 1) {
+        expect(traversalsMap.get(index)).toHaveLength(1);
+      }
+    }
+  });
+
+  it('keeps orthogonal-only placements for up/down/left/right neighbors', () => {
+    const candidates = generatePadavaliLayouts({
+      words: smallWords,
+      dimensions: [3, 3],
+      seed: 21,
+      attempts: 24,
+      neighborhood: 'n4'
+    });
+
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(candidates.every((candidate) => candidate.neighborhood === 'n4')).toBe(true);
+    expect(candidates.every(pathStepsAreOrthogonal)).toBe(true);
+  });
+
+  it('keeps left-to-right and top-to-bottom runs for straight laying', () => {
+    const candidates = generatePadavaliLayouts({
+      words: smallWords,
+      dimensions: [4, 4],
+      seed: 7,
+      attempts: 24,
+      pathStyle: 'straight'
+    });
+
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(candidates.every(pathIsStraightAcrossOrDown)).toBe(true);
+  });
+
+  it('omits words that cannot fit on a tiny grid', () => {
+    const candidates = generatePadavaliLayouts({
+      words: [
+        { word: 'यमुना', added: true },
+        { word: 'कावेरी', added: true }
+      ],
+      dimensions: [2, 2],
+      seed: 3,
+      attempts: 20
+    });
+
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(candidates.some((candidate) => candidate.omittedSlotIndices.length > 0)).toBe(true);
+    expect(candidates.every((candidate) => candidate.score.placedSyllableCount <= 4)).toBe(true);
+  });
+
+  it('offers distinct candidate arrangements', () => {
+    const candidates = generatePadavaliLayouts({
+      words: smallWords,
+      dimensions: [3, 3],
+      seed: 8,
+      attempts: 36,
+      maxCandidates: 8
+    });
+
+    const keys = new Set(candidates.map((candidate) => candidate.gridData.flat().join('|')));
+    expect(keys.size).toBe(candidates.length);
+  });
+
+  it('reorders without regenerating', () => {
+    const candidates = generatePadavaliLayouts({
+      words: smallWords,
+      dimensions: [3, 3],
+      seed: 4,
+      attempts: 20
+    });
+    const byFill = rankGeneratedLayouts(candidates, 'fill');
+    const byWords = rankGeneratedLayouts(candidates, 'words');
+    expect(byFill).toHaveLength(candidates.length);
+    expect(byWords).toHaveLength(candidates.length);
+    if (byFill.length > 1) {
+      expect(byFill[0]!.score.emptyCellCount).toBeLessThanOrEqual(byFill[1]!.score.emptyCellCount);
+    }
+  });
+
+  it('packs a full-size 6×6 word list without cell-color conflicts', () => {
+    const sample = SAMPLE_DATA[0]!;
+    const words = sample.word_list.map((word) => ({ word, added: true }));
+    const candidates = generatePadavaliLayouts({
+      words,
+      dimensions: sample.grid_dimensions,
+      seed: 9,
+      attempts: 24,
+      maxCandidates: 4
+    });
+
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(candidates[0]!.score.placedWordCount).toBeGreaterThanOrEqual(6);
+
+    const candidate = candidates[0]!;
+    const previewList = words.map((entry, index) =>
+      candidate.omittedSlotIndices.includes(index) ? { ...entry, added: false } : entry
+    );
+    const validWords = previewList.filter((entry) => entry.added).map((entry) => entry.word);
+    const traversalsMap = findAllTraversals(
+      candidate.gridData,
+      sample.grid_dimensions,
+      validWords,
+      candidate.neighborhood
+    );
+    const colorMap = buildCellWordColorMap(
+      traversalsMap,
+      getActiveNonEmptyWordSlotIndices(previewList)
+    );
+
+    expect(colorMap.size).toBe(candidate.score.placedSyllableCount);
+    for (const info of colorMap.values()) {
+      expect(info.conflict).toBe(false);
+    }
+  });
+
+  it('recovers playable layouts from dense packs that would otherwise be empty', () => {
+    const denseWords = ['अन', 'नल', 'लम', 'मय', 'यर', 'रत'].map((word) => ({
+      word,
+      added: true
+    }));
+    const flexible = generatePadavaliLayouts({
+      words: denseWords,
+      dimensions: [3, 3],
+      seed: 7,
+      attempts: 48,
+      pathStyle: 'flexible',
+      neighborhood: 'n8'
+    });
+    const straight = generatePadavaliLayouts({
+      words: denseWords,
+      dimensions: [3, 3],
+      seed: 7,
+      attempts: 48,
+      pathStyle: 'straight',
+      neighborhood: 'n8'
+    });
+    expect(flexible.length).toBeGreaterThan(0);
+    expect(straight.length).toBeGreaterThan(0);
+    expect(flexible.every((candidate) => candidate.score.placedWordCount > 0)).toBe(true);
+  });
+});

--- a/src/util/puzzle/layout_generator.ts
+++ b/src/util/puzzle/layout_generator.ts
@@ -18,7 +18,7 @@ export type LayoutNeighborhoodMode = GridNeighborhood | 'all';
  */
 export type LayoutPathStyle = 'flexible' | 'straight';
 
-export type LayoutRanking = 'words' | 'fill' | 'compact';
+export type LayoutRanking = 'words' | 'fill';
 
 /** Left→right and top→bottom only. */
 const STRAIGHT_DIRECTIONS: readonly Coordinate[] = [
@@ -667,13 +667,9 @@ export function rankGeneratedLayouts(
         ? right.score.placedWordCount - left.score.placedWordCount ||
           left.score.emptyCellCount - right.score.emptyCellCount ||
           left.score.compactness - right.score.compactness
-        : ranking === 'fill'
-          ? left.score.emptyCellCount - right.score.emptyCellCount ||
-            right.score.placedWordCount - left.score.placedWordCount ||
-            left.score.compactness - right.score.compactness
-          : left.score.compactness - right.score.compactness ||
-            left.score.emptyCellCount - right.score.emptyCellCount ||
-            right.score.placedWordCount - left.score.placedWordCount;
+        : left.score.emptyCellCount - right.score.emptyCellCount ||
+          right.score.placedWordCount - left.score.placedWordCount ||
+          left.score.compactness - right.score.compactness;
     return (
       scoreDifference ||
       left.score.turnCount - right.score.turnCount ||

--- a/src/util/puzzle/layout_generator.ts
+++ b/src/util/puzzle/layout_generator.ts
@@ -1,0 +1,684 @@
+import {
+  findAllTraversals,
+  neighborhoodDirections,
+  type Coordinate,
+  type GridNeighborhood
+} from '~/tools/puzzle/puzzle_tools';
+import { splitDevanagariAksharas } from '~/util/puzzle/devanagari_syllables';
+import { isWordAdded } from '~/util/puzzle/word_list';
+import { createEmptyGridData } from '~/util/puzzle/slug';
+
+/** Neighbor-move mode exposed in the editor. */
+export type LayoutNeighborhoodMode = GridNeighborhood | 'all';
+
+/**
+ * Word order along each path:
+ * - `flexible` — syllables may turn using the chosen neighborhood
+ * - `straight` — syllables run only left→right or top→bottom
+ */
+export type LayoutPathStyle = 'flexible' | 'straight';
+
+export type LayoutRanking = 'words' | 'fill' | 'compact';
+
+/** Left→right and top→bottom only. */
+const STRAIGHT_DIRECTIONS: readonly Coordinate[] = [
+  [0, 1],
+  [1, 0]
+];
+
+export type GeneratedLayoutPlacement = {
+  slotIndex: number;
+  path: Coordinate[];
+};
+
+export type GeneratedLayoutScore = {
+  placedWordCount: number;
+  placedSyllableCount: number;
+  emptyCellCount: number;
+  compactness: number;
+  turnCount: number;
+};
+
+export type GeneratedPadavaliLayout = {
+  gridData: string[][];
+  neighborhood: GridNeighborhood;
+  placements: GeneratedLayoutPlacement[];
+  placedSlotIndices: number[];
+  omittedSlotIndices: number[];
+  score: GeneratedLayoutScore;
+};
+
+type PreparedWord = {
+  slotIndex: number;
+  word: string;
+  normalized: string;
+  syllables: string[];
+};
+
+type InternalPlacement = GeneratedLayoutPlacement & {
+  word: PreparedWord;
+};
+
+const DEFAULT_MAX_CANDIDATES = 12;
+const DEFAULT_ATTEMPTS = 48;
+const DEFAULT_SEARCH_NODES = 700;
+const MAX_PATHS_PER_WORD = 10;
+const MAX_PATH_SEARCH_NODES = 90;
+
+function createRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function shuffled<T>(items: readonly T[], random: () => number): T[] {
+  const result = [...items];
+  for (let index = result.length - 1; index > 0; index -= 1) {
+    const otherIndex = Math.floor(random() * (index + 1));
+    const item = result[index]!;
+    result[index] = result[otherIndex]!;
+    result[otherIndex] = item;
+  }
+  return result;
+}
+
+function cloneGrid(grid: string[][]): string[][] {
+  return grid.map((row) => [...row]);
+}
+
+function isEmptyCell(grid: string[][], row: number, col: number): boolean {
+  return (grid[row]?.[col] ?? '').trim() === '';
+}
+
+function inBounds(row: number, col: number, dimensions: [number, number]): boolean {
+  return row >= 0 && col >= 0 && row < dimensions[0] && col < dimensions[1];
+}
+
+function cellKey(row: number, col: number): string {
+  return `${row},${col}`;
+}
+
+function pathKey(path: readonly Coordinate[]): string {
+  return path.map(([row, col]) => cellKey(row, col)).join('>');
+}
+
+function pathTurnCount(path: readonly Coordinate[]): number {
+  if (path.length < 3) return 0;
+  let turns = 0;
+  for (let index = 2; index < path.length; index += 1) {
+    const previous = path[index - 2]!;
+    const current = path[index - 1]!;
+    const next = path[index]!;
+    const dRow = current[0] - previous[0];
+    const dCol = current[1] - previous[1];
+    if (next[0] - current[0] !== dRow || next[1] - current[1] !== dCol) {
+      turns += 1;
+    }
+  }
+  return turns;
+}
+
+function emptyCells(grid: string[][], dimensions: [number, number]): Coordinate[] {
+  const cells: Coordinate[] = [];
+  for (let row = 0; row < dimensions[0]; row += 1) {
+    for (let col = 0; col < dimensions[1]; col += 1) {
+      if (isEmptyCell(grid, row, col)) cells.push([row, col]);
+    }
+  }
+  return cells;
+}
+
+function occupiedCount(grid: string[][]): number {
+  let count = 0;
+  for (const row of grid) {
+    for (const cell of row) {
+      if (cell.trim() !== '') count += 1;
+    }
+  }
+  return count;
+}
+
+function hasOccupiedNeighbor(
+  grid: string[][],
+  row: number,
+  col: number,
+  neighborhood: GridNeighborhood,
+  dimensions: [number, number]
+): boolean {
+  for (const [dRow, dCol] of neighborhoodDirections(neighborhood)) {
+    const nextRow = row + dRow;
+    const nextCol = col + dCol;
+    if (!inBounds(nextRow, nextCol, dimensions)) continue;
+    if (!isEmptyCell(grid, nextRow, nextCol)) return true;
+  }
+  return false;
+}
+
+function gridBounds(grid: string[][]): {
+  minRow: number;
+  minCol: number;
+  maxRow: number;
+  maxCol: number;
+} | null {
+  let minRow = Number.POSITIVE_INFINITY;
+  let minCol = Number.POSITIVE_INFINITY;
+  let maxRow = -1;
+  let maxCol = -1;
+  let found = false;
+  for (let row = 0; row < grid.length; row += 1) {
+    for (let col = 0; col < grid[row]!.length; col += 1) {
+      if (grid[row]![col]!.trim() === '') continue;
+      found = true;
+      minRow = Math.min(minRow, row);
+      minCol = Math.min(minCol, col);
+      maxRow = Math.max(maxRow, row);
+      maxCol = Math.max(maxCol, col);
+    }
+  }
+  return found ? { minRow, minCol, maxRow, maxCol } : null;
+}
+
+function collectStraightPaths(
+  grid: string[][],
+  length: number,
+  directions: readonly Coordinate[],
+  dimensions: [number, number]
+): Coordinate[][] {
+  if (length <= 0) return [];
+  if (length === 1) {
+    return emptyCells(grid, dimensions).map((cell) => [cell]);
+  }
+
+  const paths: Coordinate[][] = [];
+  const seen = new Set<string>();
+
+  for (let row = 0; row < dimensions[0]; row += 1) {
+    for (let col = 0; col < dimensions[1]; col += 1) {
+      if (!isEmptyCell(grid, row, col)) continue;
+      for (const [dRow, dCol] of directions) {
+        const path: Coordinate[] = [[row, col]];
+        let fits = true;
+        for (let step = 1; step < length; step += 1) {
+          const nextRow = row + dRow * step;
+          const nextCol = col + dCol * step;
+          if (!inBounds(nextRow, nextCol, dimensions) || !isEmptyCell(grid, nextRow, nextCol)) {
+            fits = false;
+            break;
+          }
+          path.push([nextRow, nextCol]);
+        }
+        if (!fits) continue;
+        const key = pathKey(path);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        paths.push(path);
+      }
+    }
+  }
+  return paths;
+}
+
+/** Free-turning paths using the active neighborhood. */
+function collectFlexiblePaths(
+  grid: string[][],
+  length: number,
+  neighborhood: GridNeighborhood,
+  dimensions: [number, number],
+  random: () => number,
+  maxPaths: number
+): Coordinate[][] {
+  if (length <= 0 || maxPaths <= 0) return [];
+
+  const paths: Coordinate[][] = [];
+  const seen = new Set<string>();
+  const directions = neighborhoodDirections(neighborhood);
+  const filled = occupiedCount(grid) > 0;
+  let nodes = 0;
+
+  const starts = shuffled(emptyCells(grid, dimensions), random).toSorted((left, right) => {
+    if (!filled) return 0;
+    const leftTouch = hasOccupiedNeighbor(grid, left[0], left[1], neighborhood, dimensions);
+    const rightTouch = hasOccupiedNeighbor(grid, right[0], right[1], neighborhood, dimensions);
+    if (leftTouch === rightTouch) return 0;
+    return leftTouch ? -1 : 1;
+  });
+
+  const visit = (path: Coordinate[], visited: Set<string>) => {
+    if (paths.length >= maxPaths || nodes >= MAX_PATH_SEARCH_NODES) return;
+    nodes += 1;
+    if (path.length === length) {
+      const key = pathKey(path);
+      if (!seen.has(key)) {
+        seen.add(key);
+        paths.push(path.map((cell): Coordinate => [cell[0], cell[1]]));
+      }
+      return;
+    }
+
+    const current = path[path.length - 1]!;
+    const options: { row: number; col: number; rank: number }[] = [];
+
+    for (const [dRow, dCol] of directions) {
+      const nextRow = current[0] + dRow;
+      const nextCol = current[1] + dCol;
+      if (!inBounds(nextRow, nextCol, dimensions)) continue;
+      if (visited.has(cellKey(nextRow, nextCol))) continue;
+      if (!isEmptyCell(grid, nextRow, nextCol)) continue;
+      const touches = hasOccupiedNeighbor(grid, nextRow, nextCol, neighborhood, dimensions);
+      options.push({ row: nextRow, col: nextCol, rank: (touches ? 1 : 0) + random() });
+    }
+
+    options.sort((left, right) => right.rank - left.rank);
+    for (const option of options) {
+      const key = cellKey(option.row, option.col);
+      visited.add(key);
+      path.push([option.row, option.col]);
+      visit(path, visited);
+      path.pop();
+      visited.delete(key);
+      if (paths.length >= maxPaths || nodes >= MAX_PATH_SEARCH_NODES) return;
+    }
+  };
+
+  for (const start of starts) {
+    if (paths.length >= maxPaths) break;
+    visit([start], new Set([cellKey(start[0], start[1])]));
+  }
+  return paths;
+}
+
+function scorePath(
+  path: readonly Coordinate[],
+  grid: string[][],
+  neighborhood: GridNeighborhood,
+  dimensions: [number, number]
+): number {
+  let touchScore = 0;
+  if (occupiedCount(grid) > 0) {
+    for (const [row, col] of path) {
+      if (hasOccupiedNeighbor(grid, row, col, neighborhood, dimensions)) touchScore += 1;
+    }
+  }
+  return touchScore - pathTurnCount(path);
+}
+
+function collectPathsForWord(
+  grid: string[][],
+  length: number,
+  neighborhood: GridNeighborhood,
+  pathStyle: LayoutPathStyle,
+  dimensions: [number, number],
+  random: () => number
+): Coordinate[][] {
+  if (length > emptyCells(grid, dimensions).length) return [];
+
+  const seen = new Set<string>();
+  const merged: Coordinate[][] = [];
+  const add = (path: Coordinate[]) => {
+    const key = pathKey(path);
+    if (seen.has(key)) return;
+    seen.add(key);
+    merged.push(path);
+  };
+
+  if (pathStyle === 'straight') {
+    for (const path of shuffled(
+      collectStraightPaths(grid, length, STRAIGHT_DIRECTIONS, dimensions),
+      random
+    ).slice(0, MAX_PATHS_PER_WORD)) {
+      add(path);
+    }
+    return merged;
+  }
+
+  for (const path of shuffled(
+    collectStraightPaths(grid, length, neighborhoodDirections(neighborhood), dimensions),
+    random
+  ).slice(0, 4)) {
+    add(path);
+  }
+  for (const path of collectFlexiblePaths(
+    grid,
+    length,
+    neighborhood,
+    dimensions,
+    random,
+    Math.max(2, MAX_PATHS_PER_WORD - merged.length)
+  )) {
+    add(path);
+  }
+
+  return merged
+    .toSorted(
+      (left, right) =>
+        scorePath(right, grid, neighborhood, dimensions) -
+        scorePath(left, grid, neighborhood, dimensions)
+    )
+    .slice(0, MAX_PATHS_PER_WORD);
+}
+
+function placeSyllables(
+  grid: string[][],
+  path: readonly Coordinate[],
+  syllables: readonly string[]
+): string[][] {
+  const next = cloneGrid(grid);
+  for (let index = 0; index < path.length; index += 1) {
+    const [row, col] = path[index]!;
+    next[row]![col] = syllables[index]!;
+  }
+  return next;
+}
+
+function layoutScore(
+  grid: string[][],
+  placements: readonly InternalPlacement[]
+): GeneratedLayoutScore {
+  const bounds = gridBounds(grid);
+  const compactness =
+    bounds === null ? 0 : (bounds.maxRow - bounds.minRow + 1) * (bounds.maxCol - bounds.minCol + 1);
+  const placedSyllableCount = placements.reduce(
+    (total, placement) => total + placement.word.syllables.length,
+    0
+  );
+  const cellCount = grid.length * (grid[0]?.length ?? 0);
+  return {
+    placedWordCount: placements.length,
+    placedSyllableCount,
+    emptyCellCount: Math.max(0, cellCount - placedSyllableCount),
+    compactness,
+    turnCount: placements.reduce((total, placement) => total + pathTurnCount(placement.path), 0)
+  };
+}
+
+function rebuildGridFromPlacements(
+  placements: readonly InternalPlacement[],
+  dimensions: [number, number]
+): string[][] {
+  let grid = createEmptyGridData(dimensions);
+  for (const placement of placements) {
+    grid = placeSyllables(grid, placement.path, placement.word.syllables);
+  }
+  return grid;
+}
+
+function isPlayableLayout(
+  grid: string[][],
+  placements: readonly InternalPlacement[],
+  dimensions: [number, number],
+  neighborhood: GridNeighborhood
+): boolean {
+  if (placements.length === 0) return false;
+  const words = placements.map((placement) => placement.word.normalized);
+  const traversalsMap = findAllTraversals(grid, dimensions, words, neighborhood);
+  const owners = new Map<string, number>();
+
+  for (let index = 0; index < words.length; index += 1) {
+    const traversals = traversalsMap.get(index) ?? [];
+    if (traversals.length !== 1) return false;
+    for (const [row, col] of traversals[0]!) {
+      const key = cellKey(row, col);
+      const owner = owners.get(key);
+      if (owner !== undefined && owner !== index) return false;
+      owners.set(key, index);
+    }
+  }
+  return true;
+}
+
+/**
+ * Drop ambiguous words until the remaining pack has unique traversals.
+ * Dense packs often maximize fill but fail playability under n8.
+ */
+function trimToPlayablePlacements(
+  placements: readonly InternalPlacement[],
+  dimensions: [number, number],
+  neighborhood: GridNeighborhood
+): { grid: string[][]; placements: InternalPlacement[] } | null {
+  let current = [...placements];
+  while (current.length > 0) {
+    const grid = rebuildGridFromPlacements(current, dimensions);
+    if (isPlayableLayout(grid, current, dimensions, neighborhood)) {
+      return { grid, placements: current };
+    }
+
+    const words = current.map((placement) => placement.word.normalized);
+    const traversalsMap = findAllTraversals(grid, dimensions, words, neighborhood);
+    let dropIndex = current.length - 1;
+    let worstTraversalCount = -1;
+    for (let index = 0; index < current.length; index += 1) {
+      const traversalCount = (traversalsMap.get(index) ?? []).length;
+      if (traversalCount === 1) continue;
+      if (traversalCount > worstTraversalCount) {
+        worstTraversalCount = traversalCount;
+        dropIndex = index;
+      }
+    }
+    current = current.filter((_, index) => index !== dropIndex);
+  }
+  return null;
+}
+
+function toCandidate(
+  placements: InternalPlacement[],
+  allWords: readonly PreparedWord[],
+  neighborhood: GridNeighborhood,
+  dimensions: [number, number]
+): GeneratedPadavaliLayout | null {
+  const playable = trimToPlayablePlacements(placements, dimensions, 'n8');
+  if (!playable) return null;
+  const { grid, placements: kept } = playable;
+  const placed = new Set(kept.map((placement) => placement.slotIndex));
+  return {
+    gridData: cloneGrid(grid),
+    neighborhood,
+    placements: kept.map(({ slotIndex, path }) => ({
+      slotIndex,
+      path: path.map((cell): Coordinate => [cell[0], cell[1]])
+    })),
+    placedSlotIndices: kept.map((placement) => placement.slotIndex),
+    omittedSlotIndices: allWords
+      .filter((word) => !placed.has(word.slotIndex))
+      .map((word) => word.slotIndex),
+    score: layoutScore(grid, kept)
+  };
+}
+
+function candidateKey(candidate: GeneratedPadavaliLayout): string {
+  return candidate.gridData.map((row) => row.join('\0')).join('\n');
+}
+
+function neighborhoodForAttempt(mode: LayoutNeighborhoodMode, attempt: number): GridNeighborhood {
+  if (mode === 'n4' || mode === 'n8') return mode;
+  return attempt % 2 === 0 ? 'n8' : 'n4';
+}
+
+function isBetterScore(
+  current: GeneratedLayoutScore,
+  best: GeneratedLayoutScore,
+  pathStyle: LayoutPathStyle
+): boolean {
+  if (current.placedWordCount !== best.placedWordCount) {
+    return current.placedWordCount > best.placedWordCount;
+  }
+  if (current.emptyCellCount !== best.emptyCellCount) {
+    return current.emptyCellCount < best.emptyCellCount;
+  }
+  if (current.compactness !== best.compactness) {
+    return current.compactness < best.compactness;
+  }
+  if (pathStyle === 'straight' && current.turnCount !== best.turnCount) {
+    return current.turnCount < best.turnCount;
+  }
+  return false;
+}
+
+function prepareWords(
+  words: readonly { word: string; added?: boolean; slotIndex?: number }[]
+): PreparedWord[] {
+  const prepared: PreparedWord[] = [];
+  for (let slotIndex = 0; slotIndex < words.length; slotIndex += 1) {
+    const entry = words[slotIndex]!;
+    if (!isWordAdded(entry)) continue;
+    const normalized = entry.word.normalize('NFC').trim();
+    const syllables = splitDevanagariAksharas(normalized);
+    if (syllables.length === 0) continue;
+    prepared.push({
+      slotIndex: entry.slotIndex ?? slotIndex,
+      word: entry.word,
+      normalized,
+      syllables
+    });
+  }
+  return prepared;
+}
+
+/**
+ * Pack added Padavali words as disjoint akṣara-paths on a fixed-size grid.
+ * Words that cannot fit stay omitted so applying a partial candidate is safe.
+ */
+export function generatePadavaliLayouts({
+  words,
+  dimensions,
+  maxCandidates = DEFAULT_MAX_CANDIDATES,
+  attempts = DEFAULT_ATTEMPTS,
+  seed = 1,
+  neighborhood = 'n8',
+  pathStyle = 'flexible'
+}: {
+  words: readonly { word: string; added?: boolean; slotIndex?: number }[];
+  dimensions: [number, number];
+  maxCandidates?: number;
+  attempts?: number;
+  seed?: number;
+  neighborhood?: LayoutNeighborhoodMode;
+  pathStyle?: LayoutPathStyle;
+}): GeneratedPadavaliLayout[] {
+  const prepared = prepareWords(words);
+  if (prepared.length === 0 || dimensions[0] < 1 || dimensions[1] < 1) return [];
+
+  const candidates: GeneratedPadavaliLayout[] = [];
+  const candidateKeys = new Set<string>();
+  const random = createRandom(seed);
+
+  for (let attempt = 0; attempt < attempts && candidates.length < maxCandidates; attempt += 1) {
+    const attemptNeighborhood = neighborhoodForAttempt(neighborhood, attempt);
+    const orderedWords = shuffled(prepared, random).toSorted(
+      (left, right) => right.syllables.length - left.syllables.length
+    );
+    let searchNodes = 0;
+    const best: {
+      current: {
+        grid: string[][];
+        placements: InternalPlacement[];
+        score: GeneratedLayoutScore;
+      } | null;
+    } = { current: null };
+
+    const search = (index: number, grid: string[][], placements: InternalPlacement[]) => {
+      if (searchNodes >= DEFAULT_SEARCH_NODES) return;
+      searchNodes += 1;
+      const currentScore = layoutScore(grid, placements);
+      if (!best.current || isBetterScore(currentScore, best.current.score, pathStyle)) {
+        best.current = { grid, placements, score: currentScore };
+      }
+      if (index >= orderedWords.length) return;
+
+      const word = orderedWords[index]!;
+      const paths = collectPathsForWord(
+        grid,
+        word.syllables.length,
+        attemptNeighborhood,
+        pathStyle,
+        dimensions,
+        random
+      );
+      for (const path of paths) {
+        const nextGrid = placeSyllables(grid, path, word.syllables);
+        search(index + 1, nextGrid, [...placements, { slotIndex: word.slotIndex, path, word }]);
+        if (searchNodes >= DEFAULT_SEARCH_NODES) return;
+      }
+      search(index + 1, grid, placements);
+    };
+
+    search(0, createEmptyGridData(dimensions), []);
+    if (!best.current || best.current.placements.length === 0) continue;
+    const candidate = toCandidate(
+      best.current.placements,
+      prepared,
+      attemptNeighborhood,
+      dimensions
+    );
+    if (!candidate) continue;
+    const key = candidateKey(candidate);
+    if (candidateKeys.has(key)) continue;
+    candidateKeys.add(key);
+    candidates.push(candidate);
+  }
+
+  // Last resort: one-word packs so the UI never hits an empty result when anything fits.
+  if (candidates.length === 0) {
+    const fallbackNeighborhood =
+      neighborhood === 'n4' || neighborhood === 'n8' ? neighborhood : 'n8';
+    for (const word of prepared) {
+      const paths = collectPathsForWord(
+        createEmptyGridData(dimensions),
+        word.syllables.length,
+        fallbackNeighborhood,
+        pathStyle,
+        dimensions,
+        random
+      );
+      for (const path of paths) {
+        const candidate = toCandidate(
+          [{ slotIndex: word.slotIndex, path, word }],
+          prepared,
+          fallbackNeighborhood,
+          dimensions
+        );
+        if (!candidate) continue;
+        const key = candidateKey(candidate);
+        if (candidateKeys.has(key)) continue;
+        candidateKeys.add(key);
+        candidates.push(candidate);
+        if (candidates.length >= maxCandidates) break;
+      }
+      if (candidates.length >= maxCandidates) break;
+    }
+  }
+
+  return rankGeneratedLayouts(candidates, 'words');
+}
+
+/** Sort existing candidates without generating new ones. */
+export function rankGeneratedLayouts(
+  candidates: readonly GeneratedPadavaliLayout[],
+  ranking: LayoutRanking
+): GeneratedPadavaliLayout[] {
+  const sorted = [...candidates];
+  sorted.sort((left, right) => {
+    const scoreDifference =
+      ranking === 'words'
+        ? right.score.placedWordCount - left.score.placedWordCount ||
+          left.score.emptyCellCount - right.score.emptyCellCount ||
+          left.score.compactness - right.score.compactness
+        : ranking === 'fill'
+          ? left.score.emptyCellCount - right.score.emptyCellCount ||
+            right.score.placedWordCount - left.score.placedWordCount ||
+            left.score.compactness - right.score.compactness
+          : left.score.compactness - right.score.compactness ||
+            left.score.emptyCellCount - right.score.emptyCellCount ||
+            right.score.placedWordCount - left.score.placedWordCount;
+    return (
+      scoreDifference ||
+      left.score.turnCount - right.score.turnCount ||
+      candidateKey(left).localeCompare(candidateKey(right))
+    );
+  });
+  return sorted;
+}

--- a/src/util/puzzle/word_colors.ts
+++ b/src/util/puzzle/word_colors.ts
@@ -155,6 +155,21 @@ export function buildCellWordColorMap(
   return result;
 }
 
+/** Color map from known placement paths (no path rediscovery). */
+export function buildCellWordColorMapFromPlacements(
+  placements: readonly { slotIndex: number; path: readonly (readonly [number, number])[] }[]
+): Map<string, CellWordColorInfo> {
+  const traversalsMap = new Map<number, readonly (readonly [number, number][])[]>();
+  const slotIndices: number[] = [];
+  for (let index = 0; index < placements.length; index += 1) {
+    const placement = placements[index]!;
+    slotIndices.push(placement.slotIndex);
+    const path = placement.path.map(([row, col]) => [row, col] as [number, number]);
+    traversalsMap.set(index, [path]);
+  }
+  return buildCellWordColorMap(traversalsMap, slotIndices);
+}
+
 /** CSS custom properties so light/dark follow the `dark` class without JS theme reads. */
 export function wordColorCssVars(pair: WordColorPair): CSSProperties {
   return {
@@ -167,6 +182,21 @@ export function wordColorCssVars(pair: WordColorPair): CSSProperties {
 
 /** Soft fill — `!` so it reliably overrides Input `dark:bg-input/30`. */
 export const wordColorTintClassName = '!bg-[var(--word-tint)] dark:!bg-[var(--word-tint-dark)]';
+
+/** Tint class + CSS vars for a grid cell, shared by the editor and layout previews. */
+export function cellWordTintAppearance(info: CellWordColorInfo | undefined): {
+  className: string;
+  style: CSSProperties | undefined;
+} {
+  if (!info) {
+    return { className: '', style: undefined };
+  }
+  const pair = info.conflict ? WORD_COLOR_CONFLICT : getWordColorPair(info.slotIndex);
+  return {
+    className: wordColorTintClassName,
+    style: wordColorCssVars(pair)
+  };
+}
 
 export const wordColorSwatchClassName =
   '!bg-[var(--word-swatch)] dark:!bg-[var(--word-swatch-dark)]';


### PR DESCRIPTION
- **Add Padavali grid layout generator with neighbor and word-order controls.**
- **default**
- **Add soft word-path trails to the padavali editor and layout previews.**
- **Add per-word soft tints and word-list keyboard nav to the crossword editor.**
